### PR TITLE
Fix snappy docs

### DIFF
--- a/docs/afc-klipper-add-on/installation/install-menu.md
+++ b/docs/afc-klipper-add-on/installation/install-menu.md
@@ -59,10 +59,11 @@ defaults to *true* and is recommended to be left as such.
     This boolean is used to enable or disable the hub cutter. Hub cutters are a remote filament cutter not 
     co-located with the toolhead. Examples of this include user mods such as `Snappy` and other EREC based mods. This 
     defaults to *false* as the recommended setup is to use a toolhead cutter. If the hub cutter is enabled, ensure that 
-    the options in the `~/printer_data/config/AFC/AFC.cfg` file are set correctly.
+    the options in the `~/printer_data/config/AFC/AFC_<unit_type>.cfg` file are set correctly in the `[AFC_hub <hub>]`
+     section. 
 === "Configuration"
-    Once set, this option can be changed via editing the `AFC.cfg` file typically located in the 
-    `~/printer_data/config/AFC` directory.
+    Once set, this option can be changed via editing the `AFC_<unit_type>.cfg` file typically located in the 
+    `~/printer_data/config/AFC` directory. These changes should be made in the `[AFC_hub <hub>]` section.
 
 #### `5. Kick Macro`
 


### PR DESCRIPTION
This pull request includes changes to update the submodule commit and improve the documentation for the AFC Klipper Add-On. The most important changes include updating the submodule commit reference and clarifying the configuration instructions in the installation guide.

Submodule update:

* [`AFC-Klipper-Add-On`](diffhunk://#diff-804b2efa6d870e57e63b72d4f62dac99f30d0db82173e3fbe9b649fa4df81539L1-R1): Updated the submodule commit to the latest version.

Documentation improvements:

* [`docs/afc-klipper-add-on/installation/install-menu.md`](diffhunk://#diff-84f66857aa43023a93f9cbc8b557f72d88e5320b871342d09bdd37a4050512b6L62-R66): Clarified the configuration instructions by specifying the correct file and section to edit for enabling the hub cutter.