### PR TITLE
Add Hotend diagram reference to hotend settings page

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -7,6 +7,10 @@ are in `AFC/AFC_Hardware.cfg`, `variable_retract_length` and `variable_pushback_
 `AFC/AFC_Macro_Vars.cfg`. For `tool_stn`, if you have `pin_tool_end` defined, use the second value; otherwise, use
 the first value. You may need to increase this value if you are using a ram buffer as the toolhead sensor.
 
+Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
+
+![revo-voron-filamatrix-cw2-diagram](../../assets/images/example-cw2-revo.png)
+
 ### Hotend specific values
 
 === "Revo Voron"

--- a/docs/boxturtle/vendors.md
+++ b/docs/boxturtle/vendors.md
@@ -1,12 +1,16 @@
 # BoxTurtle Sourcing & Vendors
 
-While BoxTurtle can be mostly self-sourced, some vendors offer partial or full BoxTurtle kits. These vendors also have
-dedicated channels on the Armored Turtle Discord.
+While BoxTurtle can be mostly self-sourced, some vendors offer partial or full BoxTurtle kits. Vetted vendors are listed below, also have
+dedicated vendor channels on the Armored Turtle Discord.
 
 If you purchase a kit from a vendor not on this list, it has not been validated in any way by the ArmoredTurtle team for
 either quality or completeness. For best results we recommend using a trusted vendor from the list below whenever
 possible. If you are a vendor and would like to be added to this list, please open a ticket on our Discord to request
 being added.
+
+If you have questions about the legitimacy of a kit, we highly suggest you *research/ask before purchasing it*
+
+**[Caveat emptor](https://en.wikipedia.org/wiki/Caveat_emptor)!**
 
 US:
 


### PR DESCRIPTION
also updates vendor page, closing out older PR.