### PR TITLE
Remove redundant type definitions for Box Turtle and NightOwl units i…

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
@@ -391,7 +391,6 @@ typically used to define the unit name and other options that are specific to th
 
 ``` cfg
 [AFC_BoxTurtle Turtle_1]
-type: 'Box Turtle'
 #    The type of the unit. This should be set to `Box Turtle` for all
 #    BoxTurtle units.
 hub:
@@ -487,9 +486,6 @@ typically used to define the unit name and other options that are specific to th
 
 ``` cfg
 [AFC_NightOwl NightOwl_1]
-type: 'NightOwl'
-#    The type of the unit. This should be set to `NightOwl` for all
-#    NightOwl units.
 hub:
 #    Default: <none>
 #    Hub name(AFC_hub) that belongs to this unit. can be overriden in 

--- a/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
@@ -391,8 +391,6 @@ typically used to define the unit name and other options that are specific to th
 
 ``` cfg
 [AFC_BoxTurtle Turtle_1]
-#    The type of the unit. This should be set to `Box Turtle` for all
-#    BoxTurtle units.
 hub:
 #    Default: <none>
 #    Hub name(AFC_hub) that belongs to this unit. can be overriden in 


### PR DESCRIPTION

This pull request updates the configuration documentation for AFC unit types in the `docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md` file. The changes focus on removing type definitions for specific units.

Documentation updates:

* Removed the `type` field and its associated comments for the `Box Turtle` unit in the `[AFC_BoxTurtle Turtle_1]` section.
* Removed the `type` field and its associated comments for the `NightOwl` unit in the `[AFC_NightOwl NightOwl_1]` section.