### PR TITLE
Add tool servo configuration options and direct drive feature

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_Macro_Vars.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_Macro_Vars.cfg.md
@@ -138,6 +138,12 @@ variable_conf_name_stepper_y: "tmc2209 stepper_y"
 variable_conf_name_stepper_dual_carriage: "tmc2209 dual_carriage"
 variable_conf_name_stepper_z: "tmc2209 stepper_z"
 variable_awd: False
+
+# Addon variables for cutter pin servo control
+variable_tool_servo_enable        : False
+variable_tool_servo_name          : "tool_cut"
+variable_tool_servo_angle_out     : 115
+variable_tool_servo_angle_in      : 0
 ```
 
 -----
@@ -342,6 +348,30 @@ engage different combinations of steppers for that motion. If enabled, the value
     This is the value that is used to define whether system is using 'AWD' to adjust these for multiple X or Y 
     steppers. 
     This value should be set to `True` or `False`.
+
+-----
+=== "variable_tool_servo_enable"
+    Default: `False`  
+    This is the value that is used to define whether the tool servo is enabled. 
+    This value should be set to `True` or `False`.
+
+-----
+=== "variable_tool_servo_name"
+    Default: `"tool_cut"`  
+    This is the value that is used to define the name of the tool servo in the printer.cfg file. 
+    This value should be set to the name of the servo in your printer.cfg file.
+
+-----
+=== "variable_tool_servo_angle_out"
+    Default: `115`  
+    This is the value that is used to define the angle of the tool servo when it is out. 
+    This value should be set to the angle of the servo in degrees.
+
+-----
+=== "variable_tool_servo_angle_in"
+    Default: `0`  
+    This is the value that is used to define the angle of the tool servo when it is in. 
+    This value should be set to the angle of the servo in degrees.
 
 ## [_AFC_POOP_VARS]
 

--- a/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
@@ -557,3 +557,26 @@ unload_on_runout: False
 #    triggered and spool to swap is not set (infinite spool). Setting
 #    value here overrides values set in AFC.cfg file.
 ```
+## [servo tool_cut] Section
+
+The following options are available for all units (BoxTurtle, HTLF, and NightOwl) and allow for the configuration and 
+operation of a gantry mounted servo to assist in tool cutting. 
+
+``` cfg
+[servo tool_cut]
+#--=================================================================================--#
+######### Tip Cut Servo ###############################################################
+#--=================================================================================--#
+pin: YOUR_SERVO_PIN_HERE
+#    This should be the MCU/pin combination for the servo pin.
+minimum_pulse_width: 0.00053
+#    Adjust this value until a '_CUTTER_SERVO POS=out' extends the pin 
+#    fully without a buzzing sound.
+maximum_pulse_width: 0.0023
+#    Adjust this value until a '_CUTTER_SERVO POS=in' retracts the pin 
+#    fully without a buzzing sound.
+maximum_servo_angle: 180
+#   Initial angle (in degrees) to set the servo to. The default is to
+#   not send any signal at startup.
+
+```

--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -127,3 +127,16 @@ For example:
 server: http://192.168.1.184:7912
 sync_rate: 5
 ```
+
+## Direct Drive
+
+AFC has the ability to use direct loading straight to the extruder/toolhead. There should be no hub in-between that 
+lane and the extruder when this option is used. Using `direct` will disable the ability to use the automatic 
+calibration functions.
+
+To enable `direct` mode, the following line needs to be added to the `[AFC_stepper <lane_name>]` section in your 
+configuration:
+
+``` cfg
+hub: direct
+```

--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -34,3 +34,11 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `variable_retract_length`: 20
     - `variable_pushback_length`: 10
 
+=== "Revo Voron + G2E"
+
+    - `tool_stn`: 72
+    - `tool_stn_unload`: 62
+    - `tool_sensor_after_extruder`: 0 (if running a single sensor)
+    - `tool_unload_speed`: 25
+    - `tool_load_speed`: 25
+


### PR DESCRIPTION
This pull request introduces several updates to the AFC-Klipper-Add-On, focusing on new servo control features, configuration options, and documentation enhancements. The most significant changes include adding configuration variables and documentation for a gantry-mounted servo tool cutter, introducing a new "direct drive" mode for extruder loading, and updating hotend setup details.

### Servo Control Features:
* Added new variables for configuring a servo tool cutter, including `variable_tool_servo_enable`, `variable_tool_servo_name`, `variable_tool_servo_angle_out`, and `variable_tool_servo_angle_in`, along with detailed documentation for each variable in `AFC_Macro_Vars.cfg.md`. [[1]](diffhunk://#diff-848c61340e5525878a3f9e1142def8abbd8f8a78f353f45d1f9e17462526f329R141-R146) [[2]](diffhunk://#diff-848c61340e5525878a3f9e1142def8abbd8f8a78f353f45d1f9e17462526f329R352-R375)
* Introduced a new `[servo tool_cut]` section in `AFC_UnitType_1.cfg.md` for configuring servo parameters such as pin assignments, pulse widths, and angles.

### Configuration Enhancements:
* Added support for a "direct drive" mode in the `[AFC_stepper <lane_name>]` section, allowing direct loading to the extruder/toolhead without a hub. This disables automatic calibration functions.

### Documentation Updates:
* Expanded hotend setup documentation with new parameters for the "Revo Voron + G2E" configuration, including `tool_stn`, `tool_stn_unload`, and speed-related variables.

### Submodule Update:
* Updated the AFC-Klipper-Add-On submodule to a new commit (`b448e6c24325785082813b98c673b7d807fe28d6`).