### PR TITLE
Updating documentation for espooler assist

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_Hardware.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_Hardware.cfg.md
@@ -72,9 +72,6 @@ multiplier_low: 0.95
 led_index: Buffer_Indicator:1
 #    LED index for the buffer, used to control the buffer LED
 #    (if present).
-velocity: 0
-#    Default: 0
-#    Velocity for the forward assist.
 accel: 0
 #    Default: 0 
 #    Error if the buffer is not configured properly.

--- a/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
@@ -186,6 +186,56 @@ n20_break_delay_time: 0.200
 #    Time to wait between breaking n20 motors(nSleep/FWD/RWD all 1) 
 #    and then releasing the break to allow coasting. Setting value 
 #    here overrides values set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+enable_assist: True
+#    Default: True
+#    Enables espooler print assist. Setting value 
+#    here overrides values set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+timer_delay: 5
+#    Default: 5
+#    Affects espooler assist, number of seconds to wait before checking 
+#    filament movement for espooler print assist. Setting value here 
+#    overrides values set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+enable_kick_start: True
+#    Default: True
+#    Enables full speed espoolers for `kick_start_time` amount to
+#    help spools to start moving. Setting value here overrides values
+#    set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+kick_start_time: 0.070
+#    Default: 0.070
+#    Time in seconds to enable spooler at full speed to help with
+#    getting the spool to spin. Setting value here overrides values set 
+#    in unit (AFC_BoxTurtle/NightOwl/etc) section.
+delta_movement: 150
+#    Default: 150
+#    Affects espooler assist, delta amount in mm to move from last assist
+#    to trigger another assist move. Setting value here overrides values 
+#    set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+mm_movement: 150
+#    Default: 150
+#    Affects espooler assist, amount to move during the assist in mm once 
+#    filament has moved by `delta_movement` amount. Setting value here 
+#    overrides values set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+mm_per_rotation: 628.32
+#    Default: 628.32
+#    Affects espooler assist, distance in mm a spool travels to complete 
+#    a full spin. Setting value here overrides values set in 
+#    unit (AFC_BoxTurtle/NightOwl/etc) section.
+cycles_per_rotation: 1275
+#    Default: 1275
+#    Affects espooler assist, time it takes to in milliseconds to turn 
+#    a spool a full rotation. Setting value here overrides values set 
+#    in unit (AFC_BoxTurtle/NightOwl/etc) section.
+pwm_value: 0.6706
+#    Default: 0.6706
+#    Affects espooler assist, PWM cycle time. Setting value 
+#    here overrides values set in unit (AFC_BoxTurtle/NightOwl/etc) section.
+spoolrate: 1.0
+#    Default: 1.0
+#    Scaling factor for the following variables: 
+#      kick_start_time, mm_per_rotation, cycles_per_rotation, 
+#      pwm_value, delta_movement, mm_movement
+#    Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc)
+#    section.
 load_to_hub: True
 #    Default: True
 #    Fast loads filament to hub when inserted, set to False to disable. 
@@ -393,16 +443,65 @@ typically used to define the unit name and other options that are specific to th
 [AFC_BoxTurtle Turtle_1]
 hub:
 #    Default: <none>
-#    Hub name(AFC_hub) that belongs to this unit. can be overriden in 
+#    Hub name(AFC_hub) that belongs to this unit. can be overridden in 
 #    the [AFC_stepper] section.
 extruder:
 #    Default: <none>
 #    Extruder name(AFC_extruder) that belongs to this unit. can be
-#    overriden in the [AFC_stepper] section.
+#    overridden in the [AFC_stepper] section.
 buffer: 
 #    Default: <none>
 #    Buffer name(AFC_buffer) that belongs to this unit. can be
-#    overriden in the [AFC_stepper] section.
+#    overridden in the [AFC_stepper] section.
+enable_assist: True
+#    Default: True
+#    Enables espooler print assist
+#    Can be overridden in the [AFC_stepper] section.
+timer_delay: 5
+#    Default: 5
+#    Affects espooler assist, number of seconds to wait before 
+#    checking filament movement for espooler print assist
+#    Can be overridden in the [AFC_stepper] section.
+enable_kick_start: True
+#    Default: True
+#    Enables full speed espoolers for `kick_start_time` amount to
+#    help spools to start moving
+#    Can be overridden in the [AFC_stepper] section.
+kick_start_time: 0.070
+#    Default: 0.070
+#    Time in seconds to enable spooler at full speed to help with
+#    getting the spool to spin
+#    Can be overridden in the [AFC_stepper] section.
+delta_movement: 150
+#    Default: 150
+#    Affects espooler assist, delta amount in mm to move from last 
+#    assist to trigger another assist move
+#    Can be overridden in the [AFC_stepper] section.
+mm_movement: 150
+#    Default: 150
+#    Affects espooler assist, amount to move during the assist in mm 
+#    once filament has moved by `delta_movement` amount
+#    Can be overridden in the [AFC_stepper] section.
+mm_per_rotation: 628.32
+#    Default: 628.32
+#    Affects espooler assist, distance in mm a spool travels to complete 
+#    a full spin.
+#    Can be overridden in the [AFC_stepper] section.
+cycles_per_rotation: 1275
+#    Default: 1275
+#    Affects espooler assist, time it takes to in milliseconds to turn 
+#    a spool a full rotation
+#    Can be overridden in the [AFC_stepper] section.
+pwm_value: 0.6706
+#    Default: 0.6706
+#    Affects espooler assist, PWM cycle time
+#    Can be overridden in the [AFC_stepper] section.
+spoolrate: 1.0
+#    Default: 1.0
+#    Scaling factor for the following variables: 
+#      kick_start_time, mm_per_rotation, cycles_per_rotation, 
+#      pwm_value, delta_movement, mm_movement
+#    Can be overridden in the [AFC_stepper] section.
 led_fault: 1,0,0,0
 #    Default: 1,0,0,0
 #    LED color to set when faults occur in lane        
@@ -486,16 +585,65 @@ typically used to define the unit name and other options that are specific to th
 [AFC_NightOwl NightOwl_1]
 hub:
 #    Default: <none>
-#    Hub name(AFC_hub) that belongs to this unit. can be overriden in 
+#    Hub name(AFC_hub) that belongs to this unit. can be overridden in 
 #    the [AFC_stepper] section.
 extruder:
 #    Default: <none>
 #    Extruder name(AFC_extruder) that belongs to this unit. can be
-#    overriden in the [AFC_stepper] section.
+#    overridden in the [AFC_stepper] section.
 buffer: 
 #    Default: <none>
 #    Buffer name(AFC_buffer) that belongs to this unit. can be
-#    overriden in the [AFC_stepper] section.
+#    overridden in the [AFC_stepper] section.
+enable_assist: True
+#    Default: True
+#    Enables espooler print assist
+#    Can be overridden in the [AFC_stepper] section.
+timer_delay: 5
+#    Default: 5
+#    Affects espooler assist, number of seconds to wait before 
+#    checking filament movement for espooler print assist
+#    Can be overridden in the [AFC_stepper] section.
+enable_kick_start: True
+#    Default: True
+#    Enables full speed espoolers for `kick_start_time` amount to
+#    help spools to start moving
+#    Can be overridden in the [AFC_stepper] section.
+kick_start_time: 0.070
+#    Default: 0.070
+#    Time in seconds to enable spooler at full speed to help with
+#    getting the spool to spin
+#    Can be overridden in the [AFC_stepper] section.
+delta_movement: 150
+#    Default: 150
+#    Affects espooler assist, delta amount in mm to move from last 
+#    assist to trigger another assist move
+#    Can be overridden in the [AFC_stepper] section.
+mm_movement: 150
+#    Default: 150
+#    Affects espooler assist, amount to move during the assist in mm 
+#    once filament has moved by `delta_movement` amount
+#    Can be overridden in the [AFC_stepper] section.
+mm_per_rotation: 628.32
+#    Default: 628.32
+#    Affects espooler assist, distance in mm a spool travels to complete 
+#    a full spin.
+#    Can be overridden in the [AFC_stepper] section.
+cycles_per_rotation: 1275
+#    Default: 1275
+#    Affects espooler assist, time it takes to in milliseconds to turn 
+#    a spool a full rotation
+#    Can be overridden in the [AFC_stepper] section.
+pwm_value: 0.6706
+#    Default: 0.6706
+#    Affects espooler assist, PWM cycle time
+#    Can be overridden in the [AFC_stepper] section.
+spoolrate: 1.0
+#    Default: 1.0
+#    Scaling factor for the following variables: 
+#      kick_start_time, mm_per_rotation, cycles_per_rotation, 
+#      pwm_value, delta_movement, mm_movement
+#    Can be overridden in the [AFC_stepper] section.
 led_fault: 1,0,0,0
 #    Default: 1,0,0,0
 #    LED color to set when faults occur in lane        

--- a/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
@@ -215,11 +215,6 @@ mm_movement: 150
 #    Affects espooler assist, amount to move during the assist in mm once 
 #    filament has moved by `delta_movement` amount. Setting value here 
 #    overrides values set in unit (AFC_BoxTurtle/NightOwl/etc) section.
-mm_per_rotation: 628.32
-#    Default: 628.32
-#    Affects espooler assist, distance in mm a spool travels to complete 
-#    a full spin. Setting value here overrides values set in 
-#    unit (AFC_BoxTurtle/NightOwl/etc) section.
 cycles_per_rotation: 1275
 #    Default: 1275
 #    Affects espooler assist, time it takes to in milliseconds to turn 
@@ -232,7 +227,7 @@ pwm_value: 0.6706
 spoolrate: 1.0
 #    Default: 1.0
 #    Scaling factor for the following variables: 
-#      kick_start_time, mm_per_rotation, cycles_per_rotation, 
+#      kick_start_time, spool_outer_diameter, cycles_per_rotation, 
 #      pwm_value, delta_movement, mm_movement
 #    Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc)
 #    section.
@@ -271,7 +266,7 @@ spool_inner_diameter: 100
 #    Inner diameter of the spool in mm.
 spool_outer_diameter: 200
 #    Default: 200 
-#    Outer diameter of the spool in mm.
+#    Outer diameter of the spool in mm. Affects espooler assist logic
 empty_spool_weight: 190
 #    Default: 190
 #    Weight of the empty spool in grams.
@@ -482,11 +477,6 @@ mm_movement: 150
 #    Affects espooler assist, amount to move during the assist in mm 
 #    once filament has moved by `delta_movement` amount
 #    Can be overridden in the [AFC_stepper] section.
-mm_per_rotation: 628.32
-#    Default: 628.32
-#    Affects espooler assist, distance in mm a spool travels to complete 
-#    a full spin.
-#    Can be overridden in the [AFC_stepper] section.
 cycles_per_rotation: 1275
 #    Default: 1275
 #    Affects espooler assist, time it takes to in milliseconds to turn 
@@ -499,7 +489,7 @@ pwm_value: 0.6706
 spoolrate: 1.0
 #    Default: 1.0
 #    Scaling factor for the following variables: 
-#      kick_start_time, mm_per_rotation, cycles_per_rotation, 
+#      kick_start_time, spool_outer_diameter, cycles_per_rotation, 
 #      pwm_value, delta_movement, mm_movement
 #    Can be overridden in the [AFC_stepper] section.
 led_fault: 1,0,0,0
@@ -624,11 +614,6 @@ mm_movement: 150
 #    Affects espooler assist, amount to move during the assist in mm 
 #    once filament has moved by `delta_movement` amount
 #    Can be overridden in the [AFC_stepper] section.
-mm_per_rotation: 628.32
-#    Default: 628.32
-#    Affects espooler assist, distance in mm a spool travels to complete 
-#    a full spin.
-#    Can be overridden in the [AFC_stepper] section.
 cycles_per_rotation: 1275
 #    Default: 1275
 #    Affects espooler assist, time it takes to in milliseconds to turn 
@@ -641,7 +626,7 @@ pwm_value: 0.6706
 spoolrate: 1.0
 #    Default: 1.0
 #    Scaling factor for the following variables: 
-#      kick_start_time, mm_per_rotation, cycles_per_rotation, 
+#      kick_start_time, spool_outer_diameter, cycles_per_rotation, 
 #      pwm_value, delta_movement, mm_movement
 #    Can be overridden in the [AFC_stepper] section.
 led_fault: 1,0,0,0

--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -140,3 +140,9 @@ configuration:
 ``` cfg
 hub: direct
 ```
+
+## Espooler Print Assist
+
+AFC has the ability to activate espooler forward movement when printing to help aid in spools from
+walking around and riding up wheels when they get low. This is enabled by default and can be turned off
+by adding `enable_assist: False` to you `[AFC_BoxTurtle Turtle_(n)]` config section.

--- a/docs/afc-klipper-add-on/installation/buffer-overview.md
+++ b/docs/afc-klipper-add-on/installation/buffer-overview.md
@@ -96,7 +96,6 @@ advance_pin:     # set advance pin
 trailing_pin:    # set trailing pin
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
 multiplier_low:  0.95   # default 0.95, factor to feed less filament
-velocity: 100
 
 [AFC_buffer TN2]
 advance_pin: !turtleneck:ADVANCE
@@ -104,7 +103,6 @@ trailing_pin: !turtleneck:TRAILING
 multiplier_high: 1.05   # default 1.05, factor to feed more filament
 multiplier_low:  0.95   # default 0.95, factor to feed less filament
 led_index: Buffer_Indicator:1
-velocity: 100
 
 ```
 

--- a/docs/afc-klipper-add-on/klipper/internal/buffer.md
+++ b/docs/afc-klipper-add-on/klipper/internal/buffer.md
@@ -24,13 +24,6 @@ These macros are used to manage the buffer and its properties.
       heading_level: 3
 
 -----
-[SET_BUFFER_VELOCITY]
-::: AFC_buffer.AFCTrigger.cmd_SET_BUFFER_VELOCITY
-    options:
-      docstring_style: numpy
-      heading_level: 3
-
------
 [ENABLE_BUFFER]
 ::: AFC_buffer.AFCTrigger.cmd_ENABLE_BUFFER
     options:

--- a/docs/afc-klipper-add-on/klipper/internal/lane.md
+++ b/docs/afc-klipper-add-on/klipper/internal/lane.md
@@ -86,3 +86,31 @@ toolhead / extruder.
     options:
       docstring_style: numpy
       heading_level: 3
+
+-----
+[SET_ESPOOLER_VALUES]
+::: AFC_assist.Espooler.cmd_SET_ESPOOLER_VALUES
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[ENABLE_ESPOOLER_ASSIST]
+::: AFC_assist.Espooler.cmd_ENABLE_ESPOOLER_ASSIST
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[DISABLE_ESPOOLER_ASSIST]
+::: AFC_assist.Espooler.cmd_DISABLE_ESPOOLER_ASSIST
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[TEST_ESPOOLER_ASSIST]
+::: AFC_assist.Espooler.cmd_TEST_ESPOOLER_ASSIST
+    options:
+      docstring_style: numpy
+      heading_level: 3


### PR DESCRIPTION
Adding documentation for new espooler assist logic.

- Verified everything displayed correctly with local docs

Corresponds with [PR](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/pull/335/files), submodule hash has been updated.