### PR TITLE
Update documentation for AFC-Klipper-Add-On: add PrusaSlicer info and…

### DIFF
--- a/docs/afc-klipper-add-on/installation/getting-started.md
+++ b/docs/afc-klipper-add-on/installation/getting-started.md
@@ -16,7 +16,7 @@ More information about BoxTurtle can be found [here](https://github.com/ArmoredT
 
 The `AFC-Klipper-Add-On` has the following pre-requisites:
 
-- Klipper
+- Klipper 12 or later
 - Moonraker
 - WebUI (Mainsail or Fluidd)
 - Python3 >= 3.8

--- a/docs/boxturtle/initial_startup/09-slicer-config.md
+++ b/docs/boxturtle/initial_startup/09-slicer-config.md
@@ -71,3 +71,8 @@ betas/release candidates) you will need to make the following additional changes
 Because the AFC-Klipper-Add-On handles any tip forming in the extension, we need to disable these specific settings in
 the slicer software. Below is a screenshot for OrcaSlicer, but most Slic3r-based slicers have a similar dialog/setting.
 ![Orca_Ramming_Settings](../../assets/images/orca-ramming-settings.png)
+
+
+### Other slicers
+
+PrusaSlicer - https://www.youtube.com/watch?v=ilxtHVNhsM4


### PR DESCRIPTION
This pull request includes updates to documentation for the `AFC-Klipper-Add-On` project, clarifying prerequisites and adding additional resources for slicer configuration.

### Documentation Updates:

* [`docs/afc-klipper-add-on/installation/getting-started.md`](diffhunk://#diff-bd3832d1eb30c1a74fe3cc14d169d1ce6a0145ee861a0104610dcebef7ddcc84L19-R19): Updated the Klipper prerequisite to specify version 12 or later, ensuring users are aware of the minimum supported version.
* [`docs/boxturtle/initial_startup/09-slicer-config.md`](diffhunk://#diff-120094eef2edd1a60526bac07211fb9e787d6f69e51e3fc5e8a2aa0d3fac2bd2R74-R78): Added a new section with a link to a video tutorial for configuring PrusaSlicer, providing additional guidance for users of other slicers.