### PR TITLE
Update lane command references to use AFC_lane module

### DIFF
--- a/docs/afc-klipper-add-on/klipper/internal/lane.md
+++ b/docs/afc-klipper-add-on/klipper/internal/lane.md
@@ -12,7 +12,7 @@ toolhead / extruder.
 
 -----
 [SET_LANE_LOADED]
-::: AFC_stepper.AFCExtruderStepper.cmd_SET_LANE_LOADED
+::: AFC_lane.AFCLane.cmd_SET_LANE_LOADED
     options:
       docstring_style: numpy
       heading_level: 3
@@ -54,28 +54,28 @@ toolhead / extruder.
 
 -----
 [SET_SPEED_MULTIPLIER]
-::: AFC_stepper.AFCExtruderStepper.cmd_SET_SPEED_MULTIPLIER
+::: AFC_lane.AFCLane.cmd_SET_SPEED_MULTIPLIER
     options:
       docstring_style: numpy
       heading_level: 3
 
 -----
 [SAVE_SPEED_MULTIPLIER]
-::: AFC_stepper.AFCExtruderStepper.cmd_SAVE_SPEED_MULTIPLIER
+::: AFC_lane.AFCLane.cmd_SAVE_SPEED_MULTIPLIER
     options:
       docstring_style: numpy
       heading_level: 3
 
 -----
 [SET_HUB_DIST]
-::: AFC_stepper.AFCExtruderStepper.cmd_SET_HUB_DIST
+::: AFC_lane.AFCLane.cmd_SET_HUB_DIST
     options:
       docstring_style: numpy
       heading_level: 3
 
 -----
 [SAVE_HUB_DIST]
-::: AFC_stepper.AFCExtruderStepper.cmd_SAVE_HUB_DIST
+::: AFC_lane.AFCLane.cmd_SAVE_HUB_DIST
     options:
       docstring_style: numpy
       heading_level: 3


### PR DESCRIPTION
This pull request updates the documentation for the `toolhead / extruder` module by replacing references to `AFCExtruderStepper` with `AFCLane` in several command definitions. This change ensures consistency with the updated module structure.

Changes to command references in `docs/afc-klipper-add-on/klipper/internal/lane.md`:

* Updated `[SET_LANE_LOADED]` command reference from `AFC_stepper.AFCExtruderStepper.cmd_SET_LANE_LOADED` to `AFC_lane.AFCLane.cmd_SET_LANE_LOADED`.
* Updated `[SET_SPEED_MULTIPLIER]` command reference from `AFC_stepper.AFCExtruderStepper.cmd_SET_SPEED_MULTIPLIER` to `AFC_lane.AFCLane.cmd_SET_SPEED_MULTIPLIER`.
* Updated `[SAVE_SPEED_MULTIPLIER]` command reference from `AFC_stepper.AFCExtruderStepper.cmd_SAVE_SPEED_MULTIPLIER` to `AFC_lane.AFCLane.cmd_SAVE_SPEED_MULTIPLIER`.
* Updated `[SET_HUB_DIST]` command reference from `AFC_stepper.AFCExtruderStepper.cmd_SET_HUB_DIST` to `AFC_lane.AFCLane.cmd_SET_HUB_DIST`.
* Updated `[SAVE_HUB_DIST]` command reference from `AFC_stepper.AFCExtruderStepper.cmd_SAVE_HUB_DIST` to `AFC_lane.AFCLane.cmd_SAVE_HUB_DIST`.