### PR TITLE
Add known issues section to troubleshooting.md

### DIFF
--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -1,5 +1,15 @@
 # Troubleshooting
 
+## Known Issues
+
+As with any project, there are some known issues that may arise. Known issues for the AFC-Klipper-Add-On project can 
+be found [here](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug).
+
+We encourage anyone who experiences an issue to check the known issues list first, and if the issue is not listed, please
+open a new issue on the GitHub repository. When opening a new issue, please provide as much detail as possible,
+following the issue template provided. This will help us to quickly identify and resolve the issue.
+
+
 ## AFC Debug Script
 
 A debug script is available to be run that can assist the Armored Turtle support team on their Discord server. To run 


### PR DESCRIPTION
This pull request adds a new "Known Issues" section to the troubleshooting documentation for the AFC-Klipper-Add-On project. The section provides guidance on how to check for existing issues and report new ones.

Documentation update:

* [`docs/troubleshooting/troubleshooting.md`](diffhunk://#diff-132c90aa3432b67b0a8dc2b67d85e6bf280a402491fe9d4a2e1b95fb35a2e998R3-R12): Added a "Known Issues" section with a link to the GitHub issues page for tracking bugs and instructions for reporting new issues using the provided issue template.