### PR TITLE
Remove deprecated SET_AFC_TOOLCHANGES references from documentation

### DIFF
--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -59,7 +59,7 @@ will be pulled from files metadata stored in moonraker. AFC will keep track of t
 current tool change number when a T(n) command is called from gcode. Make sure moonraker version is at least v0.9.3-64 to
 utilize this feature.  
 
-If you have setup your `Change filament G-code` section to use `SET_AFC_TOOLCHANGES` in your slicer please remove
+If you have set up your `Change filament G-code` section to use `SET_AFC_TOOLCHANGES` in your slicer please remove
 the following lines:
 
 ```cfg

--- a/docs/afc-klipper-add-on/klipper/internal/misc.md
+++ b/docs/afc-klipper-add-on/klipper/internal/misc.md
@@ -17,13 +17,6 @@ These macros are used for various purposes, including error handling, tool chang
       heading_level: 3
 
 -----
-[SET_AFC_TOOLCHANGES]
-::: AFC.afc.cmd_SET_AFC_TOOLCHANGES
-    options:
-      docstring_style: numpy
-      heading_level: 3
-
------
 [HUB_LOAD]
 ::: AFC.afc.cmd_HUB_LOAD
     options:

--- a/docs/boxturtle/initial_startup/09-slicer-config.md
+++ b/docs/boxturtle/initial_startup/09-slicer-config.md
@@ -32,7 +32,6 @@ PRINT_START EXTRUDER=[nozzle_temperature_initial_layer] BED=[bed_temperature_ini
 
 ``` g-code
 T[next_extruder] PURGE_LENGTH=[flush_length]
-{ if toolchange_count == 1 }SET_AFC_TOOLCHANGES TOOLCHANGES=[total_toolchanges]{endif }
 ;FLUSH_START
 ;EXTERNAL_PURGE {flush_length}
 ;FLUSH_END
@@ -48,9 +47,6 @@ changes for PrusaSlicer in [this video](https://www.youtube.com/watch?v=ilxtHVNh
 
 ``` g-code
 T[next_extruder]
-{if layer_num < 0}
-SET_AFC_TOOLCHANGES TOOLCHANGES=[total_toolchanges]
-{endif}
 ```
 
 - Under each extruder in printer settings, change the default value of 'Retraction when tool is disabled' from 10mm to


### PR DESCRIPTION
This pull request removes references to the `SET_AFC_TOOLCHANGES` macro from the documentation and associated G-code examples. The changes focus on cleaning up unused or outdated macros and simplifying G-code scripts for tool changes.

### Removal of `SET_AFC_TOOLCHANGES` macro:

* [`docs/afc-klipper-add-on/klipper/internal/misc.md`](diffhunk://#diff-b134b7b6b51a77d8d9c1786a8ec6c53a1e7a0428bb6e2bec5a871aecbed549ddL19-L25): Removed the `SET_AFC_TOOLCHANGES` macro from the documentation of AFC commands. This cleanup reflects the deprecation or obsolescence of the macro.

* `docs/boxturtle/initial_startup/09-slicer-config.md`: 
  - Removed the usage of `SET_AFC_TOOLCHANGES` within G-code examples, including conditional tool change logic. This simplifies the G-code scripts for extruder and layer-specific tool changes. [[1]](diffhunk://#diff-120094eef2edd1a60526bac07211fb9e787d6f69e51e3fc5e8a2aa0d3fac2bd2L35) [[2]](diffhunk://#diff-120094eef2edd1a60526bac07211fb9e787d6f69e51e3fc5e8a2aa0d3fac2bd2L51-L53)