### PR TITLE
Add Jabberwocky hotend values to 06-hotend-values.md

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -34,3 +34,10 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `variable_retract_length`: 20
     - `variable_pushback_length`: 10
 
+=== "Jabberwocky"
+
+    - `tool_stn`: 27.23
+    - `tool_stn_unload`: 96.8
+    - `variable_retract_length`: 21
+    - `variable_pushback_length`: 12.45
+


### PR DESCRIPTION
This pull request updates the documentation to include new hotend values for the "Jabberwocky" configuration in the `06-hotend-values.md` file. These values are added alongside the existing configuration for clarity.

### Documentation updates:
* [`docs/boxturtle/initial_startup/06-hotend-values.md`](diffhunk://#diff-bb1434ab8bd2b90ef160088a1dd59bb3ad590f8e6a42080e2267014d61826c46R37-R43): Added a new section for the "Jabberwocky" configuration, specifying values for `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length`.