### PR TITLE
Add show_macros configuration option to display AFC macros in GUI

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -160,6 +160,9 @@ print_short_stats: False
 #    Default: False
 #    When True AFC_STATS macro will print out in a skinnier format to better fit
 #    consoles that are smaller in width
+show_macros: True
+#    Default: True
+#    When True, the AFC macros will be shown in the Mainsail/Fluidd GUI.
 ```
 
 The next part of the `[AFC]` section contains the configuration for the AFC macros. These macros are used to control the


### PR DESCRIPTION
This pull request introduces a new configuration option to the `AFC.cfg.md` file, enhancing the user interface for the AFC macros in the Mainsail/Fluidd GUI.

* [`docs/afc-klipper-add-on/configuration/AFC.cfg.md`](diffhunk://#diff-0d0c4dd6a1bbaa1aae50b845e2a7a4f45b4609eb3c106d8719aeed67d754f905R163-R165): Added the `show_macros` option, which enables displaying AFC macros in the Mainsail/Fluidd GUI when set to `True`.