### PR TITLE
Add hotend values for Stealthburner, Xol-Metrix, Dragonburner, and VZ…

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -11,6 +11,11 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 
 ![revo-voron-filamatrix-cw2-diagram](../../assets/images/example-cw2-revo.png)
 
+!!!warning
+
+    These values are derived from community based feedback and are not guaranteed to work for your specific setup.
+    You may need to adjust them based on your specific hotend and extruder setup. Always test with caution.
+
 ### Hotend specific values
 
 #### Stealthburner & CW2

--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -13,6 +13,7 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 
 ### Hotend specific values
 
+#### Stealthburner & CW2
 === "Revo Voron"
 
     - `tool_stn`: 52 (if `pin_tool_end` is NOT defined) / 29 (if `pin_tool_end` is defined)
@@ -41,3 +42,127 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `variable_retract_length`: 21
     - `variable_pushback_length`: 12.45
 
+------
+
+#### Stealthburner / Other extruders
+
+=== "G2E and Dragon HF"
+
+    - `tool_stn`: 79
+    - `tool_stn_unload`: 100
+    - `variable_retract_length`: 30
+    - `variable_pushback_length`: 25
+
+=== "G2E and Mosquito Magnum"
+
+    - `tool_stn`: 72
+    - `tool_stn_unload`: 68
+    - `variable_retract_length`: 33.4
+    - `variable_pushback_length`: 33
+
+=== "G2E and Revo"
+
+    - `tool_stn`: 71
+    - `tool_stn_unload`: 105.5
+    - `variable_retract_length`: 21
+    - `variable_pushback_length`: 22.5
+
+=== "G2SA and Revo"
+
+    - `tool_stn`: 78
+    - `tool_stn_unload`: 62
+    - `variable_retract_length`: 35
+    - `variable_pushback_length`: 30
+
+------
+
+#### Xol-Metrix 
+=== "WWG2 and Rapido HF"
+
+    - `tool_stn`: 75 (without post extruder sensor)
+    - `tool_stn_unload`: 30
+    - `variable_retract_length`: 32
+    - `variable_pushback_length`: 27
+
+=== "LXG Lite and Rapido V2 HF"
+
+    - `tool_stn`: 72 
+    - `tool_stn_unload`: 54
+    - `variable_retract_length`: 2
+    - `variable_pushback_length`: 0.4
+
+=== "Orbiter and Dragon HF"
+
+    - `tool_stn`: 16
+    - `tool_stn_unload`: 70
+    - `variable_retract_length`: 17
+    - `variable_pushback_length`: 15
+
+=== "Orbiter 2 and Revo"
+    
+    - `tool_stn`: 70
+    - `tool_stn_unload`: 110
+    - `variable_retract_length`: 20
+    - `variable_pushback_length`: 0
+
+=== "Orbiter 2.5 and Rapido V2 HF"
+
+    - `tool_stn`: 72
+    - `tool_stn_unload`: 100
+    - `variable_retract_length`: 20
+    - `variable_pushback_length`: 25
+
+=== "Sherpa Mini and Rapido HF"
+
+    - `tool_stn`: 40
+    - `tool_stn_unload`: 100
+    - `variable_retract_length`: 5
+    - `variable_pushback_length`: 3
+
+=== "Sherpa Mini and Rapido V2 HF"
+
+    - `tool_stn`: 26
+    - `tool_stn_unload`: 100
+    - `variable_retract_length`: 25
+    - `variable_pushback_length`: 5
+
+=== "WWG2 and Revo"
+
+    - `tool_stn`: 30
+    - `tool_stn_unload`: 62
+    - `variable_retract_length`: 22
+    - `variable_pushback_length`: 20
+
+-------
+
+#### Dragonburner
+=== "Orbiter with Phaetus Next G"
+
+    - `tool_stn`: 75 
+    - `tool_stn_unload`: 75
+    - `variable_retract_length`: 15
+    - `variable_pushback_length`: 15
+
+=== "Orbiter with Dragon HF"
+
+    - `tool_stn`: 55 
+    - `tool_stn_unload`: 65
+    - `variable_retract_length`: 20
+    - `variable_pushback_length`: 25
+
+=== "Orbiter 2 with Phaetus Conch"
+
+    - `tool_stn`: 55 
+    - `tool_stn_unload`: 100
+    - `variable_retract_length`: 20
+    - `variable_pushback_length`: 15
+
+------
+#### VZBot Goliath
+
+=== "Vz-Hextrudort with Goliath"
+    
+    - `tool_stn`: 40
+    - `tool_stn_unload`: 60
+    - `variable_retract_length`: 12
+    - `variable_pushback_length`: 5


### PR DESCRIPTION

This pull request updates the documentation for hotend-specific values in `docs/boxturtle/initial_startup/06-hotend-values.md`. It introduces detailed configurations for various extruder and hotend combinations, organizing them into sections for better readability.

### Documentation Updates:

#### New hotend configurations:
* Added configurations for extruder-hotend combinations under "Stealthburner & CW2," "Stealthburner / Other extruders," "Xol-Metrix," "Dragonburner," and "VZBot Goliath" sections. Each combination includes values for `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length`. [[1]](diffhunk://#diff-bb1434ab8bd2b90ef160088a1dd59bb3ad590f8e6a42080e2267014d61826c46R16) [[2]](diffhunk://#diff-bb1434ab8bd2b90ef160088a1dd59bb3ad590f8e6a42080e2267014d61826c46R45-R168)