### PR TITLE
Add troubleshooting steps for flashing issues with AFC-Lite

### DIFF
--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -93,3 +93,22 @@ troubleshooting problems when you can re-crimp the connectors and test in a half
 Powering the SBC via your MCU (e.g., on a Leviathan) may also not provide sufficient power to the device. Rule out
 this as a cause by running separate power to the device.  If you are sharing multiple AC to DC PSUs, 
 ensure that the V- wires are connected together for a common reference voltage.
+
+## Flashing Issues or Errors
+
+If you are having issues flashing the AFC-Lite, please ensure that you are using the correct configuration for your device.
+
+### Error sending command: [SEND_BLOCK] to Device
+
+The easiest way to resolve this issue is to revert to a known commit in Katapult, rebuild the katapult firmware, and then
+reflash the katapult firmware to the AFC-Lite.
+
+```shell
+cd ~/katapult
+git checkout e1716657
+make clean
+make menuconfig
+make
+```
+
+Once the new katapult firmware is built, you can flash it to the AFC-Lite, and then proceed with flashing Klipper as normal.


### PR DESCRIPTION
This pull request adds a new section to the troubleshooting documentation to address flashing issues with the AFC-Lite. It provides a step-by-step guide for resolving errors during the flashing process.

**Documentation Updates:**

* [`docs/troubleshooting/troubleshooting.md`](diffhunk://#diff-132c90aa3432b67b0a8dc2b67d85e6bf280a402491fe9d4a2e1b95fb35a2e998R96-R114): Added a new subsection titled "Flashing Issues or Errors," including guidance on resolving the "[SEND_BLOCK] to Device" error by reverting to a specific Katapult commit, rebuilding the firmware, and reflashing it.