### PR TITLE
Add hotend values for Dragon ACE with UHF mini holder

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -47,6 +47,13 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `variable_retract_length`: 21
     - `variable_pushback_length`: 12.45
 
+=== "Dragon ACE with UHF <br>mini holder / 3mm spacer"
+
+    - `tool_stn`: 60
+    - `tool_stn_unload`: 106
+    - `variable_retract_length`: 22
+    - `variable_pushback_length`: 20
+
 ------
 
 #### Stealthburner / Other extruders


### PR DESCRIPTION
This pull request updates the documentation for hotend values in the `docs/boxturtle/initial_startup/06-hotend-values.md` file. The most important change is the addition of a new section for the "Dragon ACE with UHF mini holder / 3mm spacer" configuration, including its specific tool and variable length settings.

### Documentation Updates:
* Added a new configuration section titled "Dragon ACE with UHF mini holder / 3mm spacer," specifying values for `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length`.