### PR TITLE
Update enclosure docs

### DIFF
--- a/docs/afc-klipper-add-on/installation/getting-started.md
+++ b/docs/afc-klipper-add-on/installation/getting-started.md
@@ -33,7 +33,22 @@ With a Debian based system, you can install these prerequisites with the followi
 sudo apt-get install jq crudini git
 ```
 
-### Step 2: Clone the git repository
+### Step 2: Software pre-configuration
+
+The AFC-Klipper-Add-On software interfaces with Moonraker for many functions. To ensure complete compatibility, you should
+ensure that the `moonraker.conf` file is configured correctly. Please ensure that the following is present in the `[authorization]`
+section of your `moonraker.conf` file:
+
+```ini
+
+trusted_clients:
+    127.0.0.0/8
+```
+
+Other entries may be present, and should remain, but please ensure that the `127.0.0.1/8` entry is present. This allows the
+`AFC-Klipper-Add-On` software to communicate with Moonraker without requiring additional authentication.
+
+### Step 3: Clone the git repository
 
 The `AFC-Klipper-Add-On` software is available on GitHub. You can clone the repository with the following command:
 
@@ -47,7 +62,7 @@ The `AFC-Klipper-Add-On` software is available on GitHub. You can clone the repo
 
     Running these commands will clone the `AFC-Klipper-Add-On` repository to your home directory and change to the directory.
 
-### Step 3: Start the installation process
+### Step 4: Start the installation process
 
 From within the `AFC-Klipper-Add-On` directory, you can start the installation process with the following command:
 

--- a/docs/boxturtle/index.md
+++ b/docs/boxturtle/index.md
@@ -26,7 +26,7 @@ Each lane merges to a hub (combiner) with a sensor with one outlet that goes to 
 To accommodate any differences in rotation distance between the extruder in the tool head and the lane motors, BoxTurtle
 uses a toolhead buffer, like [TurtleNeck](https://github.com/ArmoredTurtle/TurtleNeck) by ArmoredTurtle.
 
-For best results we recommend the AFC-Lite, developed by [Isik's Tech @xbst](https://github.com/xbst/AFC-Lite/) as it
+For best results we recommend the AFC-Lite or AFC-Pro, developed by [Isik's Tech @xbst](https://github.com/xbst/AFC-Lite/) as it
 has the necessary sensor ports and DC brushed motor drivers used for BoxTurtle's electric respoolers.
 
 ## For best results
@@ -95,11 +95,9 @@ Different filament color transitions will require different purge volumes, and t
 your filaments and prints you are performing.
 
 ## Enclosure
-The enclosure option for BoxTurtle has been moved to
-its [own repository](https://github.com/ArmoredTurtle/BoxTurtle-Enclosure). The enclosure is
-still [under development](https://www.youtube.com/watch?v=Jjgi8q28Y2o), but the most up-to-date information on it can be
-found at that repository. Also considering [joining the ArmoredTurtle Discord](https://discord.gg/eT8zc3bvPR) to get
-progress updates as development progresses.
+The enclosure option for BoxTurtle has been moved to its [own repository](https://github.com/ArmoredTurtle/BoxTurtle-Enclosure). The enclosure is
+available at [LDO resellers](./vendors.md) worldwide and additional information can be found in its GitHub Repository. 
+Also considering [joining the ArmoredTurtle Discord](https://discord.gg/eT8zc3bvPR) to get progress updates as development progresses.
 
 ## Errata
 Identified known issues and potential workarounds are documented in the [errata section](./errata.md).


### PR DESCRIPTION
This pull request updates the documentation for the AFC-Klipper-Add-On and BoxTurtle projects. Key changes include improving installation instructions, enhancing compatibility details, and updating product recommendations and availability information.

### AFC-Klipper-Add-On Documentation Updates:
* **Installation Instructions Update**: Added a new "Software pre-configuration" step to ensure compatibility with Moonraker by configuring the `moonraker.conf` file to include a trusted client entry (`127.0.0.0/8`). This allows seamless communication without additional authentication.
* **Step Renumbering**: Adjusted the numbering of installation steps to reflect the addition of the new pre-configuration step.

### BoxTurtle Documentation Updates:
* **Product Recommendation Update**: Updated the recommendation to include both the AFC-Lite and AFC-Pro, highlighting their compatibility with BoxTurtle's electric respoolers.
* **Enclosure Information Update**: Revised the enclosure section to indicate availability through LDO resellers and provided a link to additional details in its GitHub repository.

Closes #57 