### PR TITLE
Replace hotend diagram with video explainer and add mkdocs-video plugin

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -9,7 +9,7 @@ the first value. You may need to increase this value if you are using a ram buff
 
 Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 
-![afc-cut](../../assets/images/afc_cut.gif)
+![type:video](../../assets/videos/AFC_CUT_Explainer.mp4)
 !!!warning
 
     These values are derived from community based feedback and are not guaranteed to work for your specific setup.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ theme:
     - optimize
 
 plugins:
+  - mkdocs-video
   - search:
       lang: en
   - mkdocs-simple-hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "mkdocs-github-admonitions-plugin==0.0.3",
     "mkdocs-redirects==1.2.2",
     "py-gfm>=2.0.0",
-    "mkdocstrings[python]"
+    "mkdocstrings[python]",
+    "mkdocs-video"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
This pull request introduces support for embedding videos in the documentation by replacing static GIFs with video files and adding the necessary dependencies and plugins for video handling. Below are the most important changes grouped by theme:

### Video embedding in documentation:

* Replaced a static GIF (`afc_cut.gif`) with a video file (`AFC_CUT_Explainer.mp4`) in the Revo Voron hotend documentation to provide a more detailed and dynamic explanation.

### Configuration updates for video support:

* Added the `mkdocs-video` plugin to the `mkdocs.yml` configuration file to enable video embedding in the documentation.
* Updated the `pyproject.toml` file to include `mkdocs-video` as a dependency, ensuring the necessary tools are available for video handling.