### PR TITLE
Address documentation issues

### DIFF
--- a/docs/afc-klipper-add-on/installation/buffer-overview.md
+++ b/docs/afc-klipper-add-on/installation/buffer-overview.md
@@ -24,10 +24,12 @@ Two sensor TurtleNeck-style buffers are used to modulate the rotation distance o
 The buffer's expansion or compression increases or decreases the rotation distance. 
 
 * If the `trailing` sensor is triggered, this means that the buffer is compressed, the AFC will decrease rotation 
-distance in order to move the filament quicker to the primary extruder. 
+distance in order to move the filament quicker to the primary extruder. When this `trailing` sensor is triggered, the system
+goes into an `advancing` state.
 
 * If the `advance` sensor is triggered, this means that the buffer is expanded, the AFC will increase rotation 
-distance in order to slow the filament moving to the primary extruder.
+distance in order to slow the filament moving to the primary extruder. When this `advanced` sensor is triggered, the system
+goes into a `trailing` state.
 
 ### Turtleneck 1.0
 

--- a/docs/afc-klipper-add-on/installation/slicer-setup.md
+++ b/docs/afc-klipper-add-on/installation/slicer-setup.md
@@ -1,0 +1,12 @@
+# AFC-Klipper-Add-On Slicer / Print_Start Setup
+
+## Slicer Setup for AFC-Klipper Add-On
+{%
+    include-markdown "../../boxturtle/initial_startup/09-slicer-config.md"
+%}
+
+
+## Print Start Macro for AFC-Klipper Add-On
+{%
+    include-markdown "../../boxturtle/initial_startup/10-print-start-macro.md"
+%}

--- a/docs/boxturtle/initial_startup/03-install-plugin.md
+++ b/docs/boxturtle/initial_startup/03-install-plugin.md
@@ -35,5 +35,14 @@ the setting is not there, add it:
 
 `max_extrude_only_distance: 400`
 
+Depending on your configuration, you may also need to add the following line to your `printer.cfg`'s `[extruder]` section:
+
+`max_extruder_cross_section: 50`
+
+However, this should only be added if a warning appears in the logs about the extruder cross-section being too small.
+If you do not see this warning, you can skip this step.
+
+
+
 For best results, reboot your printer after installing the Add-On and including it in your printer.cfg. This will ensure
 all required modules are enabled.

--- a/docs/boxturtle/wiring-guide.md
+++ b/docs/boxturtle/wiring-guide.md
@@ -2,17 +2,21 @@
 
 ## Lane numbering
 
-Lane 1 = leftmost filament lane\
-Lane 4  = rightmost filament lane
+While looking at the BoxTurtle from the front, the lanes are numbered from left to right.  
+
+Lane 1 = left most filament lane  
+Lane 4  = right most filament lane
 
 ## AFC-Lite Wiring guide
 
-Prep = Trigger Filament Sensor Switches\
+Prep = Trigger Filament Sensor Switches  
 Load = Extruder Filament Sensor Switches
 
 ![BoxTurtle_AFC-Lite_Pinout](../assets/images/boxturtle-afc-lite-pinout.png)
 
-**NOTE**: You need to connect 24V and GND to the CAN bus port pins even if you are connecting using USB-C for data transmission. The AFC-Lite PCB does not support USB Power Delivery.
+**NOTE**: You need to connect 24V and GND to the CAN bus port pins even if you are connecting using USB-C for 
+data transmission. 
+The AFC-Lite PCB does not support USB Power Delivery.
 
 ## Extruder Steppers
 | Lane | Recommended Wire Length | Recommended Wire Gauge | Connector |
@@ -23,7 +27,9 @@ Load = Extruder Filament Sensor Switches
 | Lane 4 | 520mm | Dependent on motor | JST-XH-4 |
 
 ##  Indicator LEDs
-The default configuration of the LED indicators is to create a neopixel chain of 4 LEDs, using DOUT on one LED to go to DIN of the next LED. JST-SM connectors are spec'd to provide easy disconnect for lane service, but any wire-to-wire connector can be used in their place (e.g. Molex Microfit 3).
+The default configuration of the LED indicators is to create a neopixel chain of 4 LEDs, using DOUT on one LED to go to 
+DIN of the next LED. JST-SM connectors are spec'd to provide easy disconnect for lane service, but any wire-to-wire 
+connector can be used in their place (e.g. Molex Microfit 3).
 
 | Lane | Component                                     | Recommended Wire Length | Recommended Wire Gauge | Connector                                               |
 | ---- |-----------------------------------------------| --------- | ------------|---------------------------------------------------------|
@@ -40,6 +46,11 @@ The default configuration of the LED indicators is to create a neopixel chain of
 | Lane 2 | [N20 6V 500RPM](../assets/images/N20_6V_500RPM.png)                  | 315mm | 26ga | JST-XH-2 |
 | Lane 3 | [N20 6V 500RPM](../assets/images/N20_6V_500RPM.png)                  | 415mm | 26ga | JST-XH-2 |
 | Lane 4 | [N20 6V 500RPM](../assets/images/N20_6V_500RPM.png)                  | 515mm | 26ga | JST-XH-2 |
+
+!!!note
+
+    Switches are assumed to be wired in the normally closed (NC) configuration. Each component listed below is hyperlinked to 
+    an image of the component, with it wired properly. 
 
 ## Trigger (PREP) sensors
 | Lane | Component | Recommended Wire Length | Recommended Wire Gauge | Connector |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
           - Uninstall Process: afc-klipper-add-on/installation/uninstall-process.md
           - Buffer Overview: afc-klipper-add-on/installation/buffer-overview.md
           - Buffer Ram Sensor: afc-klipper-add-on/installation/buffer-ram-sensor.md
+          - Slicer / PRINT_START Setup: afc-klipper-add-on/installation/slicer-setup.md
       - Configuration:
           - Configuration Overview: afc-klipper-add-on/configuration/configuration_overview.md
           - Configuration Files:
@@ -126,6 +127,7 @@ plugins:
           options:
             show_source: false
           paths: [./AFC-Klipper-Add-On/extras/]
+  - include-markdown
 
 
 markdown_extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "mkdocs-redirects==1.2.2",
     "py-gfm>=2.0.0",
     "mkdocstrings[python]",
-    "mkdocs-video"
+    "mkdocs-video",
+    "mkdocs-include-markdown-plugin"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Closes #63 
Closes #61 
Closes #26 

This pull request introduces updates to documentation and configuration files for the AFC-Klipper Add-On project. The changes primarily focus on improving clarity, adding new setup instructions, and enhancing the documentation structure.

### Documentation Updates:

* [`docs/afc-klipper-add-on/installation/buffer-overview.md`](diffhunk://#diff-50b9be82a038a0b0a79b731a99c96308138f289e53e7bd0ac7522cf38d0125b6L27-R32): Enhanced descriptions of sensor states (`advancing` and `trailing`) to clarify the system's behavior when sensors are triggered.
* [`docs/boxturtle/wiring-guide.md`](diffhunk://#diff-113c90834602e69ff775ac9875b45b66980b79ffff619e1b66c8410c19b5f68eL5-R19): Improved lane numbering instructions and expanded details on wiring requirements, including notes about LED indicator configurations and switch wiring assumptions. [[1]](diffhunk://#diff-113c90834602e69ff775ac9875b45b66980b79ffff619e1b66c8410c19b5f68eL5-R19) [[2]](diffhunk://#diff-113c90834602e69ff775ac9875b45b66980b79ffff619e1b66c8410c19b5f68eL26-R32) [[3]](diffhunk://#diff-113c90834602e69ff775ac9875b45b66980b79ffff619e1b66c8410c19b5f68eR50-R54)

### New Setup Instructions:

* [`docs/afc-klipper-add-on/installation/slicer-setup.md`](diffhunk://#diff-71e70aa80d7c2d043439d1b822ac72f376cf58193448dd31db3d25ce063f4a4dR1-R12): Added new sections for slicer setup and print start macro configuration, using the `include-markdown` plugin for streamlined content management.

### Configuration Enhancements:

* [`docs/boxturtle/initial_startup/03-install-plugin.md`](diffhunk://#diff-6ab5b03d172d0aaa438116e08cc08969a603870d18aa187241628bb84f69bd14R38-R46): Added optional configuration for `max_extruder_cross_section` to address potential warnings about extruder cross-section size.

### Project Structure Improvements:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R26): Added navigation entry for slicer setup documentation and introduced the `include-markdown` plugin to manage reusable content across documentation files. [[1]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R26) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R130)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R18): Included `mkdocs-include-markdown-plugin` as a dependency to support the new documentation structure.