### PR TITLE
Fix typo

### DIFF
--- a/docs/boxturtle/initial_startup/03-install-plugin.md
+++ b/docs/boxturtle/initial_startup/03-install-plugin.md
@@ -37,7 +37,7 @@ the setting is not there, add it:
 
 Depending on your configuration, you may also need to add the following line to your `printer.cfg`'s `[extruder]` section:
 
-`max_extruder_cross_section: 50`
+`max_extrude_cross_section: 50`
 
 However, this should only be added if a warning appears in the logs about the extruder cross-section being too small.
 If you do not see this warning, you can skip this step.


### PR DESCRIPTION
This pull request includes a minor correction to the documentation for configuring the `[extruder]` section in `printer.cfg`.

* [`docs/boxturtle/initial_startup/03-install-plugin.md`](diffhunk://#diff-6ab5b03d172d0aaa438116e08cc08969a603870d18aa187241628bb84f69bd14L40-R40): Fixed a typo in the configuration setting name, changing `max_extruder_cross_section` to `max_extrude_cross_section`.