### PR TITLE
Update toolhead documentation and add calculation guide

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_Hardware.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_Hardware.cfg.md
@@ -26,13 +26,13 @@ pin_tool_end: mcu:pin
 #    extruder gears. This is used to detect the presence of filament
 #    after the extruder gears.
 tool_stn: 72
-#    Default: 72              
-#    Distance in mm from the toolhead sensor (pin_tool_start)to the 
-#    tip of the nozzle in mm, if `pin_tool_end` is defined then 
-#    distance is from this sensor 
+#    Default: 72
+#    See documentation for details on how to calculate this value. 
+#    https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_stn_unload: 100
 #    Default: 100      
-#    Distance to move in mm while unloading toolhead
+#    See documentation for details on how to calculate this value.
+#    https://armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html
 tool_sensor_after_extruder: 0
 #    Default: 0
 #    Extra distance to move in mm once pre/post sensors are clear. 

--- a/docs/afc-klipper-add-on/toolhead/calculation.md
+++ b/docs/afc-klipper-add-on/toolhead/calculation.md
@@ -1,0 +1,79 @@
+# Toolhead Variable Calculation
+
+This document describes how to calculate the toolhead variable in the AFC Klipper add-on. These variables are
+crucial for ensuring that the toolhead operates correctly with the AFC system.
+
+
+!!!note 
+    The following documentation pertains to the use of a toolhead cutter primarily. While some of the information
+    may be applicable if you are using tip-forming, our official recommendation is to use a toolhead
+    cutter.
+
+These primarily consist of 2 variables:
+
+- `tool_stn`: The distance from the toolhead sensor (typically the pre-extruder sensor) to the top of any filament
+   remaining in the hotend. 
+- `tool_stn_unload`: The distance the toolhead needs to move to unload the filament.
+
+### `tool_stn` Calculation
+
+The `tool_stn` variable is the distance from the toolhead sensor to the top of any filament remaining in the hotend.
+This takes into account the amount of filament that is left in the hotend after the pushback and retract operations of
+the cut macro have been performed. 
+
+The easiest way to calculate this value is to start with a recommended value based on your toolhead/extruder combination.
+A table of common values is provided [here](../../boxturtle/initial_startup/06-hotend-values.md).
+
+!!!note 
+    It may be easier to temporarily disable the `AFC_POOP` macro while you are adjusting the `tool_stn` value, as this
+    will provide an easier way to observe the filament extruding from the hotend. Run `AFC_TOGGLE_MACRO TOOL_CUT=0` to 
+    disable the macro, and `AFC_TOGGLE_MACRO TOOL_CUT=1` to re-enable it after you have finished adjusting the value.
+
+Once you have a recommended value, fine-tune it by performing the following steps:
+
+1. Unload the filament completely from the toolhead. This can be done by using the `TOOL_UNLOAD LANE=<lane>` command in
+   the Klipper console.  
+2. Load the filament into the toolhead using a toolchange command, such as `T1`.  
+3. Observe the filament to see if it is extruding out of the hotend. If an excessive amount of filament extrudes out, 
+   you will need to decrease the `tool_stn` value. If no filament extrudes, you will need to increase the `tool_stn` value.  
+4. Repeat steps 1, 2 and 3 until you find a value that works for your toolhead/extruder combination.  
+
+Use the following command to adjust the `tool_stn` value without having to restart the system:
+
+```
+UPDATE_TOOLHEAD_SENSORS EXTRUDER=<extruder> TOOL_STN=<length>
+```
+
+Once you have found a value that works, save it to the configuration with the following command:
+
+```
+SAVE_EXTRUDER_VALUES EXTRUDER=<extruder>
+```
+
+!!!note
+    Don't forget to re-enable the `AFC_POOP` macro by running `AFC_TOGGLE_MACRO TOOL_CUT=1` after you have finished
+    adjusting the `tool_stn` value if you disabled it earlier. 
+
+### `tool_stn_unload` Calculation
+
+The `tool_stn_unload` variable is the distance that the filament moves when the toolhead is unloaded, after the cut macro
+is executed and any pushback and retract operations have been performed.
+
+Like adjusting the `tool_stn` value, start with a recommended value based on your toolhead/extruder combination 
+and use the following steps to fine-tune it:
+
+1. Completely load the filament into the toolhead using a toolchange command, such as `T1`. 
+2. Manually extrude filament until observe it coming out of the hotend. This will help reduce the changes of a
+   jam occurring during the unload operation.
+3. Manually execute the `AFC_CUT` macro to perform a cut operation.
+4. Using a manual extrude command, retract the filament by a set amount, until the toolhead sensor is no longer triggered.
+
+    For example, if your estimated `tool_stn_unload` value is `62mm`, start by issuing a manual retraction for 55mm
+    and then manually retracting 1mm at a time until the toolhead sensor is no longer triggered.
+
+5. Once you have found the value that works, save it to the configuration with the following command:
+
+```
+UPDATE_TOOLHEAD_SENSORS EXTRUDER=<extruder> TOOL_STN_UNLOAD=<length>
+SAVE_EXTRUDER_VALUES EXTRUDER=<extruder>
+```

--- a/docs/boxturtle/initial_startup/01-overview.md
+++ b/docs/boxturtle/initial_startup/01-overview.md
@@ -19,8 +19,14 @@ is [Ellis' Print Tuning Guide](https://ellis3dp.com/Print-Tuning-Guide/).
 
 ### Ensure minimum system requirements
 
-The AFC Klipper Add-On requires a minimum Klipper/Kalico version of 0.12.0, as well as a corresponding klippy-env python
-environment at least 3.x.
+The AFC Klipper Add-On requires a minimum Klipper/Kalico version of 0.12, as well as a corresponding klippy-env python
+environment at least 3.8.
+
+!!!warning "Minimum Klipper Requirements"
+
+    If you are running a version of Klipper/Kalico older than 0.12, you will need to update your system before proceeding.
+    The AFC Klipper Add-On will not work with older versions. You must be on or past commit id `1d92be71` of Klipper.
+    This was released on Jan 18th, 2024.
 
 If you are on Klipper/Kalico 12, but running `~/klippy-env/bin/python --version` returns version 2.7.x, you can
 recreate it with the following.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,10 @@ use_directory_urls: False
 nav:
   - Home:
       - index.md
+      - AFC-Klipper-Add-On: afc-klipper-add-on/index.md
+      - BoxTurtle: boxturtle/index.md
+      - AFC-Accessories: afc-accessories/index.md
+      - Troubleshooting: troubleshooting/troubleshooting.md
   - AFC-Klipper-Add-On:
       - Overview: afc-klipper-add-on/index.md
       - Features: afc-klipper-add-on/features.md
@@ -43,6 +47,8 @@ nav:
           - External Macros: afc-klipper-add-on/klipper/external/macros.md
       - Configuration Examples: afc-klipper-add-on/configuration/configuration_examples.md
       - Calibration Process: afc-klipper-add-on/installation/calibration.md
+      - Toolhead Variable Calculation:
+          - Toolhead Variable Calculation: afc-klipper-add-on/toolhead/calculation.md
   - BoxTurtle:
       - Overview: boxturtle/index.md
       - Printed Parts: boxturtle/printed-parts.md


### PR DESCRIPTION
This pull request focuses on improving documentation for the AFC Klipper Add-On by adding detailed instructions for toolhead variable calculations, updating system requirements, and enhancing navigation in the documentation site. The most important changes include the addition of a new guide for calculating toolhead variables, updates to configuration file comments with reference links, and adjustments to the minimum system requirements.

### Documentation Enhancements:

* **Added a comprehensive guide for toolhead variable calculations**: A new file, `docs/afc-klipper-add-on/toolhead/calculation.md`, provides detailed instructions for calculating `tool_stn` and `tool_stn_unload` variables, including step-by-step processes, commands, and recommendations for fine-tuning. This guide is essential for ensuring proper operation of the toolhead with the AFC system.

* **Updated configuration file comments with reference links**: The `AFC_Hardware.cfg.md` file now includes links to the new toolhead variable calculation documentation, replacing vague descriptions with specific references to help users calculate values like `tool_stn` and `tool_stn_unload`.

* **Updated minimum system requirements**: The overview documentation now specifies that the AFC Klipper Add-On requires a minimum Klipper/Kalico version of 0.12 and Python 3.8. A warning was added to inform users of the need to update their system if running older versions.

### Documentation Navigation Improvements:

* **Enhanced navigation structure in `mkdocs.yml`**: Added new entries to the navigation structure, including links to the toolhead variable calculation guide and other sections like AFC Accessories and Troubleshooting, improving the overall organization of the documentation. [[1]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R12-R15) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R50-R51)