### PR TITLE
Add Bambu X1 hotend values and tuning instructions

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -7,6 +7,8 @@ are in `AFC/AFC_Hardware.cfg`, `variable_retract_length` and `variable_pushback_
 `AFC/AFC_Macro_Vars.cfg`. For `tool_stn`, if you have `pin_tool_end` defined, use the second value; otherwise, use
 the first value. You may need to increase this value if you are using a ram buffer as the toolhead sensor.
 
+Additional instructions on tuning some of these values can be [here](../../afc-klipper-add-on/toolhead/calculation.md).  
+
 Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 
 ![type:video](../../assets/videos/AFC_CUT_Explainer.mp4)
@@ -53,6 +55,12 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `variable_retract_length`: 22
     - `variable_pushback_length`: 20
 
+=== "Bambu X1 Hotend"
+
+    - `tool_stn`: 55
+    - `tool_stn_unload`: 62
+    - `variable_retract_length`: 25
+    - `variable_pushback_length`: 23
 ------
 
 #### Stealthburner / Other extruders


### PR DESCRIPTION
This pull request updates the documentation for hotend values in the `docs/boxturtle/initial_startup/06-hotend-values.md` file. The changes include adding new tuning instructions and specific values for the Bambu X1 Hotend.

Documentation updates:

* Added a link to additional instructions for tuning hotend values in the `AFC/AFC_Hardware.cfg` section.
* Introduced a new section for the Bambu X1 Hotend, specifying values for `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length`.