### PR TITLE
Add spoolman QR references

### DIFF
--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -129,6 +129,8 @@ server: http://192.168.1.184:7912
 sync_rate: 5
 ```
 
+Support for QR scanners is provided through [SET_NEXT_SPOOL_ID](klipper/internal/spool.md#AFC_spool.AFCSpool.cmd_SET_NEXT_SPOOL_ID). A USB QR code scanner implementation [afc-spool-scan](https://github.com/kekiefer/afc-spool-scan) is available to install on the klipper host.
+
 ## Direct Drive
 
 AFC has the ability to use direct loading straight to the extruder/toolhead. There should be no hub in-between that 

--- a/docs/afc-klipper-add-on/klipper/internal/spool.md
+++ b/docs/afc-klipper-add-on/klipper/internal/spool.md
@@ -51,3 +51,10 @@ using a spool tracking system such as [Spoolman](https://github.com/Donkie/Spool
     options:
       docstring_style: numpy
       heading_level: 3
+
+-----
+[SET_NEXT_SPOOL_ID]
+::: AFC_spool.AFCSpool.cmd_SET_NEXT_SPOOL_ID
+    options:
+      docstring_style: numpy
+      heading_level: 3


### PR DESCRIPTION
Added a reference to SET_NEXT_SPOOL_ID (https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/pull/490)

Mentioned this command and the service to run USB scanners in features. The afc-spool-scan utility may be integrated into the addon, but for the time being it is referenced where it is.