### PR TITLE
Refine documentation for AFC configuration and setup, including gramm…

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_UnitType_1.cfg.md
@@ -475,6 +475,28 @@ color_order: GRB
 #    sporadic behavior of the LEDs.
 ```
 
+## [AFC_button lane_name] Section
+
+The following options are available in the `[AFC_button lane_name]` section of the `AFC_UnitType_1.cfg` file. These
+options control the configuration of the AFC system when using optional hardware buttons to control various functionality
+for each lane. Each lane may have its own button configuration, or you may have any combination of lanes configured.
+
+``` cfg
+[AFC_button lane1]
+pin: 
+#    Default: <none>
+#    The pin that the switch is connected for the specified lane. 
+#    This will typically look like `^!Turtle_1:SW6` or any valid
+#    MCU/pin combination. Ensure that you include pull-up(^) and invert(!).
+long_press_duration:
+#    Default: 1.2
+#    The duration in seconds that the button must be pressed to
+#    trigger a long press event. This is used to differentiate between
+#    a short press and a long press. 
+```
+
+More information on the configuration for this is available [here](../features.md).
+
 ## [AFC_BoxTurtle unit_name] Section
 
 The following options are available in the `[AFC_BoxTurtle unit_name]` section of the `AFC_UnitType_1.cfg` file. These

--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -106,9 +106,11 @@ not currently loaded as the PURGE_LENGTH from Orca for the first change would be
 
 `T{initial_tool} PURGE_LENGTH=100`
 
-**NOTE: If your first filament is not currently loaded and needs to change, `PURGE_LENGTH` will be zero and the poop
-macro will then use `variable_purge_length` from AFC_Macro_Vars.cfg file, so make sure this is set correctly for
-your printer**
+!!!info 
+
+    If your first filament is not currently loaded and needs to change, `PURGE_LENGTH` will be zero and the poop
+    macro will then use `variable_purge_length` from AFC_Macro_Vars.cfg file, so make sure this is set correctly for
+    your printer
 
 ## Spoolman
 
@@ -224,3 +226,34 @@ Both variables can be added/updated in `[AFC]` [section](configuration/AFC.cfg.m
 Examples of what statistics printout looks like:  
 ![stats_normal](../assets/images/afc_stats_wide.png)
 ![stats_short](../assets/images/afc_stats_short.png)
+
+## Button controls
+
+!!!note "Original Design"
+
+    The original design of this feature was created by @Trev1Ak and is available [here](https://discord.com/channels/1229586267671629945/1327060485408952340).
+
+    This feature is now built into the AFC-Klipper-Add-On and can be enabled by following the instructions below.
+
+    Do **NOT** use the provided Klipper config file from the original design, as it is not compatible with the AFC-Klipper-Add-On.
+
+An optional feature that can be supported is the use of physical buttons to control various functionality of the AFC system.
+
+If enabled, and configured properly, the following functionality can be controlled via buttons:
+
+Press >1.2 (long-press) seconds commands as follows:
+
+- If no lane is loaded to tool head it will load commanded lane.
+- If lane loaded to tool head is other than commanded lane it will unload other lane and load commanded lane.
+- If commanded; lane is loaded to tool head it will automatically unload lane
+
+Press <1.2 (short-press) seconds commands as follows:
+
+- If lane is loaded to tool head it will unload lane and eject spool
+- If another lane is loaded to tool head it will only eject commanded lane and not interrupt other lanes.
+
+BOM: 
+
+- 4ea Omron B3F-1026 switches/Optional verified off brand switches Amazon https://a.co/d/hmtJkk8
+- 4ea JST 3 pin male connectors for AFC Lite board
+- 3- Meters of 24awg or 28awg wire (your choice)

--- a/docs/boxturtle/wiring-guide.md
+++ b/docs/boxturtle/wiring-guide.md
@@ -2,17 +2,20 @@
 
 ## Lane numbering
 
-Lane 1 = leftmost filament lane\
-Lane 4  = rightmost filament lane
+Lane 1 = leftmost filament lane  
+Lane 4  = rightmost filament lane  
 
 ## AFC-Lite Wiring guide
 
-Prep = Trigger Filament Sensor Switches\
-Load = Extruder Filament Sensor Switches
+Prep = Trigger Filament Sensor Switches  
+Load = Extruder Filament Sensor Switches  
 
 ![BoxTurtle_AFC-Lite_Pinout](../assets/images/boxturtle-afc-lite-pinout.png)
 
-**NOTE**: You need to connect 24V and GND to the CAN bus port pins even if you are connecting using USB-C for data transmission. The AFC-Lite PCB does not support USB Power Delivery.
+!!!warning 
+
+    You need to connect 24V and GND to the CAN bus port pins even if you are connecting using USB-C for 
+    data transmission. The AFC-Lite PCB does not support USB Power Delivery.
 
 ## Extruder Steppers
 | Lane | Recommended Wire Length | Recommended Wire Gauge | Connector |
@@ -23,7 +26,9 @@ Load = Extruder Filament Sensor Switches
 | Lane 4 | 520mm | Dependent on motor | JST-XH-4 |
 
 ##  Indicator LEDs
-The default configuration of the LED indicators is to create a neopixel chain of 4 LEDs, using DOUT on one LED to go to DIN of the next LED. JST-SM connectors are spec'd to provide easy disconnect for lane service, but any wire-to-wire connector can be used in their place (e.g. Molex Microfit 3).
+The default configuration of the LED indicators is to create a neopixel chain of 4 LEDs, using DOUT on one LED to go to 
+DIN of the next LED. JST-SM connectors are spec'd to provide easy disconnect for lane service, but any wire-to-wire 
+connector can be used in their place (e.g. Molex Microfit 3).
 
 | Lane | Component                                     | Recommended Wire Length | Recommended Wire Gauge | Connector                                               |
 | ---- |-----------------------------------------------| --------- | ------------|---------------------------------------------------------|


### PR DESCRIPTION
This pull request introduces new documentation and updates existing content for the AFC-Klipper-Add-On, focusing on button control features, configuration details, and wiring guidance. The changes aim to enhance clarity and provide detailed instructions for users implementing these features.

### New Features and Documentation Updates:

* **Button Control Configuration**:
  - Added a new `[AFC_button lane_name]` section in `AFC_UnitType_1.cfg` to document configuration options for hardware buttons, including `pin` and `long_press_duration` settings.
  - Introduced a "Button controls" section in `features.md`, detailing functionality for long-press and short-press actions, supported hardware, and setup instructions.

* **Improved Notes and Warnings**:
  - Replaced plain text notes with formatted callouts (`!!!info` and `!!!warning`) for better readability, such as in `features.md` for `PURGE_LENGTH` behavior and in `wiring-guide.md` for CAN bus port connection requirements. [[1]](diffhunk://#diff-8fdf8b6083704e621b360c6e15674c3cbb348008c946d309159848f6fdaa2ce9L109-R113) [[2]](diffhunk://#diff-113c90834602e69ff775ac9875b45b66980b79ffff619e1b66c8410c19b5f68eL5-R18)

### Minor Adjustments:

* **Formatting Enhancements**:
  - Adjusted line breaks and spacing in `wiring-guide.md` for improved formatting and readability, including descriptions for LED indicator configurations.