### PR TITLE
Fix references to AFC_Hardware.cfg in documentation

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_Hardware.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_Hardware.cfg.md
@@ -8,7 +8,7 @@ of the AFC-Klipper-Add-On.
 
 ## [AFC_extruder extruder] Section
 
-The following options are available in the `[AFC_extruder extruder]` section of the `AFC.cfg` file. These options 
+The following options are available in the `[AFC_extruder extruder]` section of the `AFC_Hardware.cfg` file. These options 
 control the configuration of the AFC system when interfacing with the extruder / toolhead.
 
 !!! note
@@ -54,7 +54,7 @@ enable_sensors_in_gui: False
 ``` 
 
 ## [AFC_buffer buffer_name] Section
-The following options are available in the `[AFC_buffer buffer_name]` section of the `AFC.cfg` file. These options
+The following options are available in the `[AFC_buffer buffer_name]` section of the `AFC_Hardware.cfg` file. These options
 control the configuration of the AFC system when interfacing with the filament buffer.
 
 ``` cfg
@@ -79,7 +79,7 @@ accel: 0
 
 ## [AFC_led Buffer_Indicator] Section
 
-The following options are available in the `[AFC_led Buffer_Indicator]` section of the `AFC.cfg` file. These options
+The following options are available in the `[AFC_led Buffer_Indicator]` section of the `AFC_Hardware.cfg` file. These options
 control the configuration of the AFC system when interfacing with the buffer LED.
 
 ``` cfg


### PR DESCRIPTION
This pull request updates documentation for the AFC-Klipper Add-On to reflect a file name change from `AFC.cfg` to `AFC_Hardware.cfg`. The changes ensure consistency across various configuration sections.

### Documentation updates for file name consistency:

* Updated references to the configuration file in the `[AFC_extruder extruder]` section to use `AFC_Hardware.cfg` instead of `AFC.cfg`.
* Updated references to the configuration file in the `[AFC_buffer buffer_name]` section to use `AFC_Hardware.cfg` instead of `AFC.cfg`.
* Updated references to the configuration file in the `[AFC_led Buffer_Indicator]` section to use `AFC_Hardware.cfg` instead of `AFC.cfg`.