### PR TITLE
Add descriptions for various AFC accessories in index.md

### DIFF
--- a/docs/afc-accessories/index.md
+++ b/docs/afc-accessories/index.md
@@ -1,1 +1,16 @@
-**Coming Soon**
+Various AFC accessories are available to enhance the functionality of your AFC system. 
+
+Below is a list of some common accessories and their descriptions:
+
+- AFC Bypass Sensor: This sensor allows you to bypass the AFC system for specific prints or operations, providing 
+  flexibility in your printing process. It is available [here](https://github.com/ArmoredTurtle/AFC-Accessories/tree/main/AFC_Bypass).
+
+- AT Brush: This is a gantry mounted brush that can be used to clean the nozzle during or before printing. It helps 
+  maintain print quality by removing debris or residue from the nozzle. The AT Brush is available [here](https://github.com/ArmoredTurtle/AFC-Accessories/tree/main/AT_Brush).
+
+- BTIO Board: The BoxTurtle IO (BTIO) module simplifies the integration of your BoxTurtle multi-color system with your 
+  3D printer by serving as a centralized hub for all essential connections. It offers a clean, dependable interface for 
+  linking the printer, connecting the toolhead buffer, and supporting daisy-chained configurations for multi-unit 
+  expansion. BTIO also enables external power delivery when operating over USB. This modular design supports scalable, 
+  intelligent filament handling while keeping wiring complexity to a minimum. The GitHub page is available [here](https://github.com/ArmoredTurtle/AFC-Accessories/tree/main/BTIO),
+  while the actual hardware is available through LDO resellers.


### PR DESCRIPTION
This pull request updates the `docs/afc-accessories/index.md` file to replace the placeholder text with detailed descriptions of available AFC accessories. The update enhances the documentation by providing clear explanations and links to resources for each accessory.

### Documentation improvements:

* Replaced "**Coming Soon**" placeholder with a detailed overview of AFC accessories, including descriptions and links for the following:
  - **AFC Bypass Sensor**: Allows bypassing the AFC system for specific prints or operations.
  - **AT Brush**: A gantry-mounted brush for cleaning the nozzle to maintain print quality.
  - **BTIO Board**: A module for simplifying connections in the BoxTurtle multi-color system, supporting scalability and external power delivery.