### PR TITLE
Add Levendigs as a vendor for the LDO Boxturtle V1.0 kit

### DIFF
--- a/docs/boxturtle/vendors.md
+++ b/docs/boxturtle/vendors.md
@@ -33,6 +33,7 @@ EU:
 - [3Djake](https://www.3djake.ch/fr-CH/ldo-motors/boxturtle-v10)
 - [myrigs3d](https://myrigs3d.com/)
 - [zen3d](https://shop.zen3d.eu/ldo-boxturtle-v10)
+- [Levendigs](https://levendigs.com/products/ldo-boxturtle-v1-0-kit-afc-automatic-filament-changer)
 
 UK:
 


### PR DESCRIPTION
Closes #88 

This pull request adds a new vendor to the EU section of the `docs/boxturtle/vendors.md` documentation. The update ensures that users in the EU have an additional option for purchasing the BoxTurtle kit.

Vendor documentation update:

* Added `Levendigs` as a new EU vendor for the BoxTurtle v1.0 kit in `docs/boxturtle/vendors.md`.