### PR TITLE
Clarify AFC_POOP macro parameters and add 3D Lab Tech as a vendor

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -243,6 +243,8 @@ poop_cmd: AFC_POOP
 #    Macro name to call when pooping filament. Using the default AFC_POOP macro
 #    will call the macro defined in `Poop.cfg`. You can replace this with a 
 #    custom macro name if you have a different pooping method or tool.
+#    Please note that the only valid parameter for the AFC_POOP macro is
+#    `purge_length`, which defines the length of filament to purge.
 
 # Kick Settings
 kick: True                      

--- a/docs/boxturtle/vendors.md
+++ b/docs/boxturtle/vendors.md
@@ -24,6 +24,7 @@ US:
 CA:
 
 - [Sparta3D](https://sparta3d.ca/products/ldo-box-turtle-kit)
+- [3D Lab Tech](https://www.3dlabtech.ca/product/ldo-box-turtle-kit/)
 
 EU:
 


### PR DESCRIPTION
This pull request updates documentation for the AFC Klipper add-on configuration and BoxTurtle vendors list, focusing on clarifying macro usage and expanding vendor information.

Documentation improvements:

* Clarified that the only valid parameter for the `AFC_POOP` macro in `AFC.cfg.md` is `purge_length`, which specifies the length of filament to purge.

Vendor list update:

* Added `3D Lab Tech` as a Canadian vendor for the BoxTurtle kit in `vendors.md`.

Resolves #85 