### PR TITLE
Doc: Add instructions for reversing respooler motor pin assignments

### DIFF
--- a/docs/boxturtle/initial_startup/05-additional-tests.md
+++ b/docs/boxturtle/initial_startup/05-additional-tests.md
@@ -11,6 +11,22 @@ Run the ``TEST`` command against each lane (one at a time) to verify proper resp
 
 Verify that each respooler works properly by moving in reverse like respooling a spool before proceeding.
 
+If your respoolers are operating in reverse (typically seen in a Formbot kit), you can simply reverse the pin assignments
+for the respoolers.
+
+e.g.
+
+```cfg 
+afc_motor_rwd: Turtle_1:MOT1_RWD
+afc_motor_fwd: Turtle_1:MOT1_FWD
+```
+
+to 
+```cfg
+afc_motor_rwd: Turtle_1:MOT1_FWD
+afc_motor_fwd: Turtle_1:MOT1_RWD
+```
+
 ### Trigger switches
 
 Actuating the trigger switch should begin pulsing that lane's extruder motor to load filament. Verify that the switch


### PR DESCRIPTION
Closes #106 

This pull request adds a helpful troubleshooting tip to the documentation for respooler setup. If the respoolers are operating in reverse (which is common with certain hardware kits), the user is now advised to simply swap the pin assignments in their configuration file to correct the direction.

Documentation update:

* Added instructions and a configuration example for reversing pin assignments if respoolers operate in reverse, improving clarity for users setting up Formbot kits.