### PR TITLE
Add a4t rapido

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -191,7 +191,7 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 ------
 
 #### A4T
-=== "WWBMG, CrossBow Cutter, Rapido 2HF"
+=== "WWBMG (dual sensor), CrossBow Cutter, Rapido 2HF"
 
     - `tool_stn`: 40
     - `tool_stn_unload`: 65

--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -187,3 +187,13 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `tool_stn_unload`: 96.8
     - `variable_retract_length`: 21
     - `variable_pushback_length`: 12.45
+
+------
+
+#### A4T
+=== "WWBMG, CrossBow Cutter, Rapido 2HF"
+
+    - `tool_stn`: 40
+    - `tool_stn_unload`: 65
+    - `variable_retract_length`: 32
+    - `variable_pushback_length`: 27


### PR DESCRIPTION
This pull request updates the hotend values documentation to add configuration details for a new set of tools. The main change is the inclusion of settings for the "WWBMG, CrossBow Cutter, Rapido 2HF" toolset.

Documentation updates:

* Added a new section under the hotend values documentation for the "WWBMG, CrossBow Cutter, Rapido 2HF" toolset, specifying `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length` values.