### PR TITLE
Doc: Add hotend values for WWBMG (dual sensor) and Chube compact

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -197,3 +197,10 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `tool_stn_unload`: 65
     - `variable_retract_length`: 32
     - `variable_pushback_length`: 27
+
+=== "WWBMG (dual sensor), CrossBow Cutter, Chube compact"
+
+    - `tool_stn`: 28
+    - `tool_stn_unload`: 60
+    - `variable_retract_length`: 25
+    - `variable_pushback_length`: 23


### PR DESCRIPTION
This pull request updates the documentation to include configuration values for an additional hardware setup. Specifically, it adds a new example for the "WWBMG (dual sensor), CrossBow Cutter, Chube compact" configuration in the hotend values documentation.

Documentation updates:

* Added a new configuration example for "WWBMG (dual sensor), CrossBow Cutter, Chube compact" with corresponding parameter values to `docs/boxturtle/initial_startup/06-hotend-values.md`.