### PR TITLE
docs: add auto level macro configuration details to AFC.cfg.md

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -188,6 +188,10 @@ auto_home: False
 #    Default: False
 #    Enable to turn on auto homing if printer is not already homed when
 #    loading/unloading a lane.
+auto_level_macro: <none>
+#    Default: <none>
+#    Macro name to call to auto level the bed if auto_home is enabled.
+#    If set, this should be a macro such as Z_TILT_ADJUST or QUAD_GANTRY_LEVEL.
 enable_assist: True
 #    Default: True
 #    Enables espooler print assist.


### PR DESCRIPTION
This pull request adds a new configuration option to the `AFC.cfg.md` documentation for the AFC Klipper add-on. The main change is the introduction of an `auto_level_macro` setting, which allows users to specify a macro for automatic bed leveling when `auto_home` is enabled.

New configuration option:

* Added the `auto_level_macro` parameter, allowing users to specify a macro (e.g., `Z_TILT_ADJUST` or `QUAD_GANTRY_LEVEL`) to be called for auto bed leveling if `auto_home` is enabled.