### PR TITLE
Clarify tool_stn value based on pin_tool_end definition

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -74,7 +74,7 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 
 === "G2E and Revo"
 
-    - `tool_stn`: 71
+    - `tool_stn`: 71 (if `pin_tool_end` is NOT defined) / 41 (if `pin_tool_end` is defined)
     - `tool_stn_unload`: 105.5
     - `variable_retract_length`: 21
     - `variable_pushback_length`: 22.5


### PR DESCRIPTION
Updated to G2E and Revo tool_stn value based on pin_tool_end definition

<img width="781" height="996" alt="image" src="https://github.com/user-attachments/assets/50d39115-48ef-4dfe-aac3-b6689efd7806" />