### PR TITLE
docs: add disable weight check configuration option and usage notes

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -222,6 +222,11 @@ capture_td1_when_loaded: False
 #
 #    This is a global setting and can be overridden in unit specific sections
 #    eg. [AFC_Boxturtle ], [AFC_NightOwl ] etc.
+disable_weight_check: False
+#    Default: False
+#    When set to True, weight checks will be disabled when assigning spoolsIDs from
+#    Spoolman. *Warning*: This may lead to issues if the spool weights are set to 0
+#    in Spoolman or if the weight readings are inaccurate.
 ```
 
 The next part of the `[AFC]` section contains the configuration for the AFC macros. These macros are used to control the

--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -135,6 +135,13 @@ server: http://192.168.1.184:7912
 sync_rate: 5
 ```
 
+!!!note Spoolman Weight Check
+
+    When assigning a spoolID from Spoolman, either via a UI like Mainsail or Fluidd, or via a macro like `SET_SPOOL_ID`,
+    AFC will perform a check to ensure that the weight of the requested spool is not 0, null, or a negative value. If it is,
+    AFC will reject the spool assignment and log an error message identifying the error. For advanced use cases, this can 
+    be disabled by setting `disable_weight_check: True` in your `[AFC]` section of your configuration file.
+
 ### Spoolman QR Scanner Support
 
 Support for QR scanners is provided through [SET_NEXT_SPOOL_ID](klipper/internal/spool.md#AFC_spool.AFCSpool.cmd_SET_NEXT_SPOOL_ID). 


### PR DESCRIPTION

This pull request updates the AFC Klipper add-on documentation to clarify how spool weight checks are handled when assigning spool IDs from Spoolman. The changes introduce a new configuration option and provide detailed guidance on its usage and implications.

**Documentation updates for spool weight check:**

* Added a new configuration option, `disable_weight_check`, to the `[AFC]` section in `AFC.cfg.md`, allowing users to disable weight checks when assigning spool IDs from Spoolman, along with a warning about potential issues if weights are inaccurate or set to zero.
* Updated `features.md` to include a note explaining that AFC will check for non-zero, non-null, and non-negative spool weights when assigning spool IDs, and that this check can be disabled using the new `disable_weight_check` option for advanced use cases.