### PR TITLE
Fix doc link

### DIFF
--- a/docs/afc-klipper-add-on/installation/install-menu.md
+++ b/docs/afc-klipper-add-on/installation/install-menu.md
@@ -176,5 +176,5 @@ You may now quit the script or return to the main menu.
 
     Prior to restarting Klipper, ensure you check the files indicated above and modify them as necessary.
 
-    Mandatory configuration changes are located [here](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/blob/main/README.md#mandatory-configuration-changes-all)
+    Mandatory configuration changes are located [here](../../boxturtle/initial_startup/03-install-plugin.md#Post-Installation-Configuration)
     and must be changed / checked. You *WILL* experience Klipper warnings if you do not modify these settings. 

--- a/docs/boxturtle/initial_startup/03-install-plugin.md
+++ b/docs/boxturtle/initial_startup/03-install-plugin.md
@@ -22,13 +22,14 @@ using the default name). If you do not see these files, or if you see duplicate 
 this may be a caching issue with your web UI (mainsail/fluidd). Force a refresh with shift-reload or Ctrl+F5 and the
 problem should resolve itself.
 
+### Post-Installation Configuration
 After installation, please ensure sure you update the following settings:
 
 - In `AFC/AFC_Turtle_1.cfg`:
     - `canbus_uuid` if using CAN bus
     - `serial` if using USB
 - In `AFC/AFC_Hardware.cfg`
-    - `pin_tool_start` and/or ``pin_tool_end`
+    - `pin_tool_start` and/or `pin_tool_end`
 
 In your `printer.cfg`'s `[extruder]` section, update the setting `max_extrude_only_distance` to the value 400. If
 the setting is not there, add it:
@@ -42,6 +43,8 @@ Depending on your configuration, you may also need to add the following line to 
 However, this should only be added if a warning appears in the logs about the extruder cross-section being too small.
 If you do not see this warning, you can skip this step.
 
+Review all x,y,z positions in the `AFC/AFC_Macro_Vars.cfg` file to ensure they are correct for your printer for any macros
+you have enabled. 
 
 
 For best results, reboot your printer after installing the Add-On and including it in your printer.cfg. This will ensure


### PR DESCRIPTION
This pull request updates documentation to clarify and improve instructions for post-installation configuration of the AFC Klipper Add-On. The changes ensure users are directed to the correct location for mandatory configuration steps and provide additional guidance for verifying settings after installation.

Documentation improvements:

* Updated the link for mandatory configuration changes in `install-menu.md` to point to the new, more relevant section in `03-install-plugin.md`, helping users find the correct instructions more easily.
* Added a "Post-Installation Configuration" section in `03-install-plugin.md` with clear steps for updating settings in `AFC_Turtle_1.cfg`, `AFC_Hardware.cfg`, and the `[extruder]` section of `printer.cfg`.
* Corrected a formatting error in the configuration instructions for `pin_tool_start` and `pin_tool_end` in `AFC_Hardware.cfg`.
* Added a reminder to review all x, y, z positions in `AFC_Macro_Vars.cfg` to ensure they are correct for the user's printer and enabled macros.

Closes #127 