### PR TITLE
Update hotend values for G2E and Revo

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -74,10 +74,10 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
 
 === "G2E and Revo"
 
-    - `tool_stn`: 71 (if `pin_tool_end` is NOT defined) / 41 (if `pin_tool_end` is defined)
-    - `tool_stn_unload`: 105.5
-    - `variable_retract_length`: 21
-    - `variable_pushback_length`: 22.5
+    - `tool_stn`: 73 (if `pin_tool_end` is NOT defined) / 40 (if `pin_tool_end` is defined)
+    - `tool_stn_unload`: 119
+    - `variable_retract_length`: 22
+    - `variable_pushback_length`: 21
 
 === "G2SA and Revo"
 


### PR DESCRIPTION
Used this image found at https://www.armoredturtle.xyz/docs/boxturtle/initial_startup/02-flashing.html#make-note-of-any-toolhead-sensor-pins

(Weird place to find this btw as it seem more relevant to hotend values than sensor pins.)

<img width="1234" height="982" alt="image" src="https://github.com/user-attachments/assets/72d8b34f-b52f-45ee-b222-1c13c9b68861" />

These are the below measurements that I have success with.

<img width="1291" height="929" alt="image" src="https://github.com/user-attachments/assets/42077fc3-97d3-44bc-bc8a-2ca53c9e76d2" />
