### PR TITLE
Doc: Add note on ideal variable_pushback_length and variable_retract_…

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -17,6 +17,12 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     These values are derived from community based feedback and are not guaranteed to work for your specific setup.
     You may need to adjust them based on your specific hotend and extruder setup. Always test with caution.
 
+!!!note
+
+     Generally speaking, it is ideal to keep the `variable_pushback_length` within 5mm of the `variable_retract_length` 
+     to lessen the chance of molten filament causing a clog inside the toolhead assembly.
+
+
 ### Hotend specific values
 
 #### Stealthburner & CW2


### PR DESCRIPTION
…length for hotend setup

This pull request adds a helpful note to the hotend setup documentation to guide users on configuring filament retraction settings. The note advises keeping the `variable_pushback_length` within 5mm of the `variable_retract_length` to reduce the risk of filament clogs.

Documentation improvements:

* Added a note in `06-hotend-values.md` recommending that `variable_pushback_length` should be within 5mm of `variable_retract_length` to help prevent clogs in the toolhead assembly.

Closes #143 