### PR TITLE
Doc: Update variable_pushback_length values for hotend configurations

### DIFF
--- a/docs/boxturtle/initial_startup/06-hotend-values.md
+++ b/docs/boxturtle/initial_startup/06-hotend-values.md
@@ -59,7 +59,7 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `tool_stn`: 55
     - `tool_stn_unload`: 62
     - `variable_retract_length`: 25
-    - `variable_pushback_length`: 23
+    - `variable_pushback_length`: 23`
 ------
 
 #### Stealthburner / Other extruders
@@ -91,6 +91,13 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `tool_stn_unload`: 62
     - `variable_retract_length`: 35
     - `variable_pushback_length`: 30
+
+=== "LGX and Dragon UHF"
+
+    - `tool_stn`: 74.5
+    - `tool_stn_unload`: 45.0
+    - `variable_retract_length`: 33
+    - `variable_pushback_length`: 24
 
 ------
 


### PR DESCRIPTION
This pull request updates the documentation for hotend values in the initial startup guide, specifically adding new configuration values for the LGX and Dragon UHF extruders and correcting a formatting issue in the Revo Voron example.

Documentation updates:

* Added a new section for "LGX and Dragon UHF" extruders, including specific values for `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length`.
* Fixed a formatting issue in the Revo Voron hotend example by removing an extraneous backtick from the `variable_pushback_length` value.

Closes #142 