### PR TITLE
Update copyright

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,5 +218,5 @@ extra:
       make our documentation better.
 
 copyright: >
-  Copyright &copy; 2024 - 2025 Armored Turtle –
+  Copyright &copy; 2024 - 2026 Armored Turtle –
   <a href="#__consent">Change cookie settings</a>


### PR DESCRIPTION
This pull request makes a small update to the copyright year in the `mkdocs.yml` configuration file, extending it from 2025 to 2026.