### PR TITLE
Add ignore_spoolman_material_temps documentation

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -69,6 +69,10 @@ default_material_temps: default: 235, PLA:210, PETG:235, ABS:235, ASA:235
 #    Material needs to be either manually set or uses material from spoolman 
 #    if extruder temp is not set in spoolman. Follow current format to 
 #    add more filament types.
+ignore_spoolman_material_temps: False  
+#    Default: False
+#    When True, AFC will ignore temperatures set in Spoolman and use 
+#    default_material_temps instead.
 default_material_type: PLA      
 #    Default material type to assign to a spool once loaded into a lane.
 common_density_values: PLA:1.24, PETG:1.23, ABS:1.04, ASA:1.07

--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -93,6 +93,13 @@ If spoolman extruder temperature or material type is not defined AFC default's t
 default_material_temps: PLA:210, ABS:235, ASA:235 # Default temperature to set extruder when loading/unloading lanes.
 ```
 
+If spoolman extruder temperature is defined but you wish to stick to the values in the `default_material_temps` variable
+then you can set the `ignore_spoolman_material_temps` option to `true` in `AFC.cfg`
+
+```cfg
+ignore_spoolman_material_temps: True  # When True, AFC will ignore temperatures set in Spoolman and use default_material_temps instead.
+```
+
 ## Loading filament to hub
 
 For users that have a hub not located in their Box Turtle, AFC has the ability to load filament to their hub once its


### PR DESCRIPTION
Documentation update for `ignore_spoolman_material_temps` in `AFC.cfg`. Also includes a note about this config setting in the setting extruder temperatures section of `features.md`