### PR TITLE
docs: add auto spool switch configuration options and descriptions

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -283,6 +283,12 @@ lower_extruder_temp_on_change: True
 #    Default: True
 #    If False, AFC will not lower the extruder temperature during a filament change,
 #    as long as the current temperature is above the target material temperature - 5°C.
+auto_spool_switch: False               
+#    Default: False
+#    Trigger spool switch based on remaining filament weight for infinite runout instead of waiting on runout sensor. 
+auto_spool_switch_threshold: 25        
+#    Default: 25
+#    Weight in grams at or below which to trigger auto switch
 ```
 
 The next part of the `[AFC]` section contains the configuration for the AFC macros. These macros are used to control the

--- a/docs/afc-klipper-add-on/features.md
+++ b/docs/afc-klipper-add-on/features.md
@@ -298,6 +298,10 @@ Runout detection can be turned off while printing by disabling sensor in web GUI
 Example of runout enabled/disabled:
 ![runout_enabled_disabled](../assets/images/runout_switch.png)
 
+
+Additionally, AFC supports triggering a runout based on remaining weight of the filament spool. If `auto_spool_switch: True` is set in your config, then AFC will trigger a runout if the weight of the filament spool gets below the `auto_spool_switch_threshold` value set in your config. 
+This functionality is useful when the manufacturer of a filament spool leaves a hooked end at the end of the roll, which may prevent a normal runout from triggering properly. 
+
 ## TD-1 Support
 AFC has the ability to grab data from TD-1 devices that are connected to your printer. More information about this and setting it up can be found under [TD-1](td1.md) section.
 

--- a/docs/afc-klipper-add-on/klipper/internal/spool.md
+++ b/docs/afc-klipper-add-on/klipper/internal/spool.md
@@ -4,6 +4,13 @@ These commands are used to manage the spool and its properties. This allows for 
 using a spool tracking system such as [Spoolman](https://github.com/Donkie/Spoolman).
 
 -----
+[AFC_SET_SPOOL_TEMP]
+::: AFC_spool.AFCSpool.cmd_SET_SPOOL_TEMP
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
 [SET_MAP]
 ::: AFC_spool.AFCSpool.cmd_SET_MAP
     options:


### PR DESCRIPTION
This pull request introduces a new feature to the AFC Klipper Add-On, enabling automatic spool switching based on the remaining filament weight. This enhancement allows for more reliable filament runout detection, especially in cases where the physical runout sensor may not trigger due to filament shape. The documentation has been updated to describe the new configuration options and usage. Additionally, a new internal command for setting spool temperature has been documented.

**New Feature: Automatic Spool Switching Based on Weight**
- Added `auto_spool_switch` and `auto_spool_switch_threshold` configuration options to allow triggering spool switches when the remaining filament weight drops below a specified threshold, instead of relying solely on the runout sensor.
- Updated feature documentation to explain the new weight-based runout detection, its benefits, and usage scenarios.

**Documentation Improvements**
- Added documentation for the new `[AFC_SET_SPOOL_TEMP]` internal command, including options and docstring style.

**Submodule Update**
- Updated the AFC-Klipper-Add-On submodule to a new commit, likely incorporating the above features and fixes.