### PR TITLE
docs: add hotend values for WWBMG, CrossBow Cutter, and Revo Voron

### DIFF
--- a/docs/initial-startup/06-hotend-values.md
+++ b/docs/initial-startup/06-hotend-values.md
@@ -218,6 +218,13 @@ Below is an example diagram of a Revo Voron hotend on FilamATrix/Clockwork 2:
     - `variable_retract_length`: 25
     - `variable_pushback_length`: 23
 
+=== "WWBMG (dual sensor), CrossBow Cutter, Revo Voron"
+
+    - `tool_stn`: 30
+    - `tool_stn_unload`: 75
+    - `variable_retract_length`: 22
+    - `variable_pushback_length`: 20
+
 ------
 #### Custom / Other
 


### PR DESCRIPTION
This pull request adds configuration documentation for a new hotend setup to the initial startup guide. Specifically, it introduces settings for the "WWBMG (dual sensor), CrossBow Cutter, Revo Voron" configuration.

New hotend configuration documentation:

* Added a new section for "WWBMG (dual sensor), CrossBow Cutter, Revo Voron" with recommended values for `tool_stn`, `tool_stn_unload`, `variable_retract_length`, and `variable_pushback_length` in `docs/initial-startup/06-hotend-values.md`.

Closes #171 