### PR TITLE
Adding macros added for multi toolhead support

### DIFF
--- a/docs/afc-klipper-add-on/klipper/internal/misc.md
+++ b/docs/afc-klipper-add-on/klipper/internal/misc.md
@@ -45,6 +45,13 @@ These commands are used for various purposes, including error handling, tool cha
       heading_level: 3
 
 -----
+[AFC_SET_EXTRUDER_LED]
+::: AFC_extruder.AFCExtruder.cmd_AFC_SET_EXTRUDER_LED
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
 [RESET_FAILURE]
 ::: AFC_error.afcError.cmd_RESET_FAILURE
     options:
@@ -124,6 +131,20 @@ These commands are used for various purposes, including error handling, tool cha
 -----
 [AFC_HOME_UNIT]
 ::: AFC_HTLF.AFC_HTLF.cmd_AFC_HOME_UNIT
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[AFC_M104]
+::: AFC.afc.cmd_AFC_M104
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[AFC_M109]
+::: AFC.afc.cmd_AFC_M109
     options:
       docstring_style: numpy
       heading_level: 3

--- a/docs/afc-klipper-add-on/klipper/internal/toolchanger.md
+++ b/docs/afc-klipper-add-on/klipper/internal/toolchanger.md
@@ -1,0 +1,24 @@
+## Tip-Forming Related Commands
+
+These commands are available when using AFC with a toolchanger setup and `[AFC_Toolchanger <name>]` has been defined in the configuration.
+
+-----
+[AFC_SELECT_TOOL]
+::: AFC_Toolchanger.AfcToolchanger.cmd_AFC_SELECT_TOOL
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[AFC_UNSELECT_TOOL]
+::: AFC_Toolchanger.AfcToolchanger.cmd_AFC_UNSELECT_TOOL
+    options:
+      docstring_style: numpy
+      heading_level: 3
+
+-----
+[AFC_SET_TOOLHEAD_LED]
+::: AFC_Toolchanger.AfcToolchanger.cmd_AFC_SET_TOOLHEAD_LED
+    options:
+      docstring_style: numpy
+      heading_level: 3

--- a/docs/initial-startup/05-additional-tests.md
+++ b/docs/initial-startup/05-additional-tests.md
@@ -45,7 +45,7 @@
     pushing back on the filament instead of pulling it in, try reversing the `dir_pin` setting for that extruder motor in
     your unit-specific config file (e.g., `AFC/AFC_Turtle_1.cfg` for BoxTurtle).
     
-    If you are able to load filament into all lanes and get a green LED indicator, and `AFC_STATUS` at the console
+    If you are able to load filament into all lanes and get a green LED indicator, and the console
     reports no errors, move on to the next step.
 === "HTLF"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
               - Lane / Movement Commands: afc-klipper-add-on/klipper/internal/lane.md
               - Misc. Commands: afc-klipper-add-on/klipper/internal/misc.md
               - TD-1 Commands: afc-klipper-add-on/klipper/internal/td1.md
+              - Toolchanger Commands: afc-klipper-add-on/klipper/internal/toolchanger.md
           - External Macros: afc-klipper-add-on/klipper/external/macros.md
       - Configuration Examples: afc-klipper-add-on/configuration/configuration_examples.md
       - Calibration Process: afc-klipper-add-on/installation/calibration.md


### PR DESCRIPTION
Adds new macros added to support toolchangers, AFC-Klipper-Add-On [PR](<https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/pull/704>) has been created that fixes bugs and updates descriptions for some macros.

@kekiefer @weemantella please review when you get a chance