### PR TITLE
Minor formatting updates

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC_Macro_Vars.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC_Macro_Vars.cfg.md
@@ -178,14 +178,17 @@ variable_tool_servo_angle_in      : 0
 This variable works for most cutter configurations.  If the cutter pin needs to be
 configured in other axis, then comment out this variable and set the axis specific locations.
 
+-----
 === "variable_pin_loc_x"
     Default: `-1`
     Set the X location for the cutter pin if needed.
 
+-----
 === "variable_pin_loc_y"
     Default: `-1`
     Set the Y location for the cutter pin if needed.
 
+-----
 === "variable_pin_loc_z"
     Default: `-1`
     Set the Z location for the cutter pin if needed.
@@ -215,7 +218,7 @@ configured in other axis, then comment out this variable and set the axis specif
     arm is completely compressed. Take 0.5mm off this distance as a buffer. 
 
 === "Example"
-    `pin_loc_x : 9, 310`  fully compressed at 0, 310 set `cut_move_dist` to 8.5
+    `pin_loc_x : 9, 310`  fully compressed at `0, 310` set `cut_move_dist` to 8.5
 
 -----
 The following variables are used to define the speed of the cutting action.  Note that if the cut speed is too fast, 
@@ -262,6 +265,7 @@ the steppers can lose steps. Therefore, for a cut:
     complete. 
     This value should be set to `True` or `False`.
 
+-----
 === "variable_post_cut_safe_move"
     Default: `True` 
     After the cut is finished, ensure that the next move will not collide with the cutter pin.  A safe move will
@@ -341,29 +345,35 @@ For setups that don't require a safe move, comment out all of these variables.
 If `restore_position` or `post_cust_safe_move` is set, the cut macro will move to the safe position after the cut is
 finished.
 
+-----
 === "variable_safe_margin_xy"  
     Default: `60, 60`  
     Define the safe position relative to the pin park coordinates.  The values are always zero or larger.
     The x and y values are added or subtracted from the pin park to calculate the safe position.  The calculated
     position will always be toward the center of the bed.
 
+-----
 === "variable_safe_move_first"  
     Default: "x"  
     Axes to move in first when performing the safe margin move away from the cutter pin.
     Valid options are: x, y, z, xy, xz, yz, xyz
 
+-----
 === "variable_safe_loc_x"  
     Default: The X coordinate of the pin park location.  
     The X coordinate of the safe location.
 
+-----
 === "variable_safe_loc_y"  
     Default: The Y coordinate of the pin park location.  
     The Y coordinate of the safe location.
 
+-----
 === "variable_safe_loc_z"  
     Default: The Z coordinate of the pin park location.  
     The Z coordinate of the safe location.
 
+-----
 === "Examples"  
     A printer that is using a servo and has no obstructed moves should comment out all of these variables:
 ``` cfg
@@ -784,4 +794,3 @@ variable_z_hop                    : 0
     Default: `0`  
     Height to raise Z when moving to park. Leave 0 to disable.
     If you want z_hop during toolchanges please set the value in the AFC.cfg.
-```

--- a/docs/afc-klipper-add-on/installation/getting-started.md
+++ b/docs/afc-klipper-add-on/installation/getting-started.md
@@ -62,7 +62,7 @@ The `AFC-Klipper-Add-On` software is available on GitHub. You can clone the repo
 === "Command Line"
     ```bash
     cd ~
-    git clone https://github.com/ArmoredTurtle/AFC-Klipper-Add-On.git
+    git clone https://github.com/AFCProject/AFC-Klipper-Add-On.git
     cd AFC-Klipper-Add-On
     ```
 === "Explanation"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,7 @@ nav:
       - Troubleshooting: troubleshooting/troubleshooting.md
       - FAQ: troubleshooting/faq.md
   - Assembly Manual: https://armoredturtle.xyz
-  - Latest Release: https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/releases
+  - Latest Release: https://github.com/AFCProject/AFC-Klipper-Add-On/releases
 draft_docs: |
   _unpublished.md 
 


### PR DESCRIPTION
This pull request updates the AFC Klipper Add-On documentation to add new configuration variable descriptions, improve clarity, and update repository links to reflect the current project location. The most significant changes are the addition of detailed documentation for new macro variables and corrections to repository URLs.

**Documentation improvements:**

* Added documentation for new configuration variables, including `variable_pin_loc_x`, `variable_pin_loc_y`, `variable_pin_loc_z`, `variable_post_cut_safe_move`, `variable_safe_margin_xy`, `variable_safe_move_first`, `variable_safe_loc_x`, `variable_safe_loc_y`, and `variable_safe_loc_z` in `AFC_Macro_Vars.cfg.md` to clarify their purpose and default values. [[1]](diffhunk://#diff-848c61340e5525878a3f9e1142def8abbd8f8a78f353f45d1f9e17462526f329R181-R191) [[2]](diffhunk://#diff-848c61340e5525878a3f9e1142def8abbd8f8a78f353f45d1f9e17462526f329R268) [[3]](diffhunk://#diff-848c61340e5525878a3f9e1142def8abbd8f8a78f353f45d1f9e17462526f329R348-R376)
* Added an "Examples" section for safe move configuration variables to illustrate usage.

**Clarity and formatting:**

* Improved example formatting for `pin_loc_x` to use code formatting for coordinates.
* Removed an unnecessary code block closing in the Z-hop variable documentation.

**Repository and release links update:**

* Updated the GitHub repository URL in the installation instructions and the "Latest Release" link to point to the new `AFCProject` organization. [[1]](diffhunk://#diff-bd3832d1eb30c1a74fe3cc14d169d1ce6a0145ee861a0104610dcebef7ddcc84L65-R65) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L95-R95)