### PR TITLE
Document disable_tool_runout_in_bypass config option on DEV branch

### DIFF
--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -246,9 +246,9 @@ enable_tool_runout: True
 #    Default: True
 #    If enabled and toolhead sensor(s) detect filament not present while printing AFC
 #    will pause printing. The value can be overridden per toolhead in AFC_extruder config sections.
-disable_tool_runout_in_bypass: False
+enable_runout_in_bypass: False
 #    Default: False
-#    If set to True, the toolhead sensor will not trigger a print pause if runout
+#    If set to True, the toolhead sensor will trigger a print pause if runout
 #    occurs while printing in bypass/manual mode (where no AFC lane is registered as loaded).
 test_extrude_amt: 10
 #    Default: 10

--- a/docs/afc-klipper-add-on/configuration/AFC.cfg.md
+++ b/docs/afc-klipper-add-on/configuration/AFC.cfg.md
@@ -246,6 +246,10 @@ enable_tool_runout: True
 #    Default: True
 #    If enabled and toolhead sensor(s) detect filament not present while printing AFC
 #    will pause printing. The value can be overridden per toolhead in AFC_extruder config sections.
+disable_tool_runout_in_bypass: False
+#    Default: False
+#    If set to True, the toolhead sensor will not trigger a print pause if runout
+#    occurs while printing in bypass/manual mode (where no AFC lane is registered as loaded).
 test_extrude_amt: 10
 #    Default: 10
 #    Amount in mm to extrude when use the `AFC_TEST_LANES` calibration


### PR DESCRIPTION
Toll runout detection in bypass mode is now enabled by default.  This documents how to disable it if users want to revert to the previous behavior.